### PR TITLE
Added device error handling

### DIFF
--- a/.config/rubocop/config.yml
+++ b/.config/rubocop/config.yml
@@ -3,6 +3,9 @@ inherit_gem:
 
 plugins: rubocop-sequel
 
+Metrics/MethodLength:
+  Exclude:
+    - app/views/helpers.rb
 RSpec/SpecFilePathFormat:
   CustomTransform:
     Terminus: ""

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-monads (1.8.1)
+    dry-monads (1.8.2)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
@@ -208,7 +208,7 @@ GEM
       dry-transformer (~> 1.0, < 2)
     hanami-validations (2.2.0)
       dry-validation (>= 1.10, < 2)
-    hanami-view (2.2.0)
+    hanami-view (2.2.1)
       dry-configurable (~> 1.0)
       dry-core (~> 1.0)
       dry-inflector (~> 1.0, < 2)
@@ -382,7 +382,7 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.1)
+    rubocop-ast (1.39.0)
       parser (>= 3.3.1.0)
     rubocop-capybara (2.22.1)
       lint_roller (~> 1.1)
@@ -555,7 +555,7 @@ CHECKSUMS
   dry-initializer (3.2.0) sha256=37d59798f912dc0a1efe14a4db4a9306989007b302dcd5f25d0a2a20c166c4e3
   dry-logger (1.0.4) sha256=031746bdc94eadda78dff3ab42d015331de869bfc11285379438be1e759175e4
   dry-logic (1.6.0) sha256=da6fedbc0f90fc41f9b0cc7e6f05f5d529d1efaef6c8dcc8e0733f685745cea2
-  dry-monads (1.8.1) sha256=c741237677f77e0a55453dad1d8d351b223b95327cc246703bddd823251c1b55
+  dry-monads (1.8.2) sha256=662e0b4515bc41048e0e2c033db86327839649a53bff383489096e47a71f22b0
   dry-monitor (1.0.1) sha256=4ac8ed1f85b14bfde1aa0bce9496d7d2fc699c5a4a1131010c8014d5f9e7a309
   dry-schema (1.13.4) sha256=caeb644de0be412d347eb4a6d91c56ceef8ec22cfceb98e80d03d354954b1d2a
   dry-struct (1.8.0) sha256=74c38b559924fb6462ac43ec780c4533a082d7b1d238a8d7857b773b3b8e2966
@@ -585,7 +585,7 @@ CHECKSUMS
   hanami-router (2.2.0) sha256=88534072b6efb5976b30608b70065bcdbaa602282600e37cb0cb5e9d2077c042
   hanami-utils (2.2.0) sha256=7884ed3ef637697487d7cb57045adec3325b9273c550a34b0d0f0332ccee5f5a
   hanami-validations (2.2.0) sha256=87957a131ddd7350ba4387afd831e64c37669cdf56c9c2107eb0f748ec3c78e6
-  hanami-view (2.2.0) sha256=fc2b927dc94db6d03e2d5e7f88185c5e9b3620025c6c891a35c40f95d09beeba
+  hanami-view (2.2.1) sha256=09179b2ce6f30e1b9e939d85f44cf11ca4803bad7a91788376586b0e31bb2560
   hanami-webconsole (2.2.0) sha256=486fba76c2664a63fcd30729d9c97a763264944dc120ff6b3ad1e29ad06e0931
   hansi (0.2.1) sha256=7e27dfd729f1692a3a7690fc0ef3af9d5e3cfc0285bb135cae7e56180e4805db
   htmx (2.1.0) sha256=b8e904e381767e1e1fdcb6822779588409b1da5a42129603967c63d0d9fff08c
@@ -657,7 +657,7 @@ CHECKSUMS
   rspec-mocks (3.13.2) sha256=2327335def0e1665325a9b617e3af9ae20272741d80ac550336309a7c59abdef
   rspec-support (3.13.2) sha256=cea3a2463fd9b84b9dcc9685efd80ea701aa8f7b3decb3b3ce795ed67737dbec
   rubocop (1.74.0) sha256=06138a35d7d11c963d5abc0148b355e3999007cb0225a619940db0e75521379b
-  rubocop-ast (1.38.1) sha256=80ecbe2ac9bb26693cab9405bf72b41b85a1f909f20f021b983c32c2e7d857fe
+  rubocop-ast (1.39.0) sha256=b6ba0f677ceced033b81c69405ac8931f4963116c572b8da5e15a03619a8236c
   rubocop-capybara (2.22.1) sha256=ced88caef23efea53f46e098ff352f8fc1068c649606ca75cb74650970f51c0c
   rubocop-disable_syntax (0.1.1) sha256=fba0b24edbd3de049ccaac8473c18fed308b5bd991e389a3368965f6cb88edbb
   rubocop-packaging (0.5.2) sha256=a36753777573161318ab627a380510c80bfdef2ef2a5b55ad313f923efd20fc7

--- a/app/actions/devices/create.rb
+++ b/app/actions/devices/create.rb
@@ -28,8 +28,19 @@ module Terminus
             device = repository.create parameters[:device]
             response.render show_view, device: repository.find(device.id), layout: false
           else
-            response.render new_view, errors: parameters.errors[:device], layout: false
+            render_new response, parameters
           end
+        end
+
+        private
+
+        # :reek:FeatureEnvy
+        def render_new response, parameters
+          response.render new_view,
+                          device: nil,
+                          fields: parameters[:device],
+                          errors: parameters.errors[:device],
+                          layout: false
         end
       end
     end

--- a/app/actions/devices/edit.rb
+++ b/app/actions/devices/edit.rb
@@ -14,10 +14,7 @@ module Terminus
 
           halt :unprocessable_entity unless parameters.valid?
 
-          response.render view,
-                          device: repository.find(parameters[:id]),
-                          errors: Dry::Core::EMPTY_HASH,
-                          layout: false
+          response.render view, device: repository.find(parameters[:id]), layout: false
         end
       end
     end

--- a/app/actions/devices/new.rb
+++ b/app/actions/devices/new.rb
@@ -6,7 +6,7 @@ module Terminus
       # The new action.
       class New < Terminus::Action
         def handle *, response
-          response.render view, errors: Dry::Core::EMPTY_HASH, layout: false
+          response.render view, layout: false
         end
       end
     end

--- a/app/actions/devices/update.rb
+++ b/app/actions/devices/update.rb
@@ -26,6 +26,8 @@ module Terminus
           parameters = request.params
           device = repository.find parameters[:id]
 
+          halt :unprocessable_entity unless device
+
           if parameters.valid?
             save device, parameters, response
           else
@@ -41,8 +43,13 @@ module Terminus
           response.render show_view, device: repository.find(id), layout: false
         end
 
+        # :reek:FeatureEnvy
         def edit device, parameters, response
-          response.render edit_view, device:, errors: parameters.errors[:device], layout: false
+          response.render edit_view,
+                          device:,
+                          fields: parameters[:device],
+                          errors: parameters.errors[:device],
+                          layout: false
         end
       end
     end

--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -14,39 +14,87 @@
   color: hsl(4, 73%, 43%);
 }
 
-.site-form {
+.popover-trigger {
+  cursor: help;
+  border: none;
+  background: none;
+}
+
+.popover-content {
+  &::backdrop {
+    backdrop-filter: brightness(60%);
+  }
+
+  border-radius: 0.5rem;
+  padding: 2rem;
+
+  .label {
+    text-align: center;
+  }
+
+  .close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    filter: grayscale(100);
+    position: absolute;
+    right: 0.25rem;
+    top: 0.5rem;
+  }
+
+  .screen_reader:not(:focus):not(:active) {
+    clip-path: inset(50%);
+    clip: rect(0 0 0 0);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+}
+
+.page-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin: 2rem 0;
+
+  .label {
+    margin: 0;
+  }
+}
+
+.page-form {
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-color: oklch(from var(--site-grey) l c h / 0.1);
-  border-radius: 0.5rem;
-  padding: 1rem;
 
   .group {
     border: none;
-    align-items: center;
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
     justify-content: center;
-
-    @media only screen and (min-width: 825px) {
-      justify-content: space-between;
-    }
   }
 
-  .label {
+  .form-field {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+  }
+
+  .key {
     align-items: center;
     display: flex;
     flex-direction: column;
+    font-weight: 600;
     gap: 0.5rem;
-    min-width: 5rem;
   }
 
   .value {
     border-radius: 0.5rem;
     border: 0.1rem solid var(--site-grey);
-    padding: 0.5rem;
+    padding: 0.3rem;
   }
 
   .form-actions {
@@ -57,6 +105,7 @@
   .accept, .decline {
     background: none;
     border: none;
+    cursor: pointer;
     font-size: 1rem;
     text-decoration: underline;
   }
@@ -68,9 +117,17 @@
   .decline {
     color: var(--site-red);
   }
-}
 
-.site-errors {
-  color: var(--site-red);
-  margin: 1rem 0;
+  .error {
+    .value {
+      border: 0.15rem solid var(--site-red);
+    }
+
+    .message {
+      color:  var(--site-red);
+      font-size: 0.9rem;
+      padding: 0.2rem 0 0.1rem 0.3rem;
+      margin: 0;
+    }
+  }
 }

--- a/app/assets/css/defaults.css
+++ b/app/assets/css/defaults.css
@@ -4,11 +4,10 @@ html, body {
 
 html {
   accent-color: var(--site-red);
-  background-color: var(--site-white);
+  background-color: oklch(from var(--site-grey) l c h / 0.2);
   font-family: var(--site-font-family);
   scrollbar-color: var(--site-white) var(--site-red);
   text-size-adjust: none;
-
   -webkit-text-size-adjust: none;
 }
 

--- a/app/assets/css/devices.css
+++ b/app/assets/css/devices.css
@@ -1,7 +1,4 @@
 .page-devices {
-  display: flex;
-  flex-direction: column;
-
   .columns, .row {
     align-items: center;
     border-radius: 0.5rem;
@@ -26,36 +23,62 @@
   }
 
   .devices {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    margin: 0 0 1rem 0;
-    padding: 0;
+    display: grid;
+    grid-gap: 2.5rem;
+    grid-template: 1fr / repeat(auto-fit, 320px);
+    justify-content: center;
+    margin-top: 2rem;
   }
 
   .device {
     align-items: center;
+    background-color: var(--site-white);
+    border-radius: 0.5rem;
+    box-shadow:
+      0.7px 0.7px 0.7px rgba(0, 0, 0, 0.022),
+      1.7px 1.7px 1.7px rgba(0, 0, 0, 0.031),
+      3.5px 3.5px 3.5px rgba(0, 0, 0, 0.039),
+      7.3px 7.3px 7.3px rgba(0, 0, 0, 0.048),
+      20px 20px 20px rgba(0, 0, 0, 0.07)
+    ;
     display: flex;
-    gap: 1rem;
-    list-style: none;
     flex-direction: column;
-  }
-
-  .label, .value {
-    list-style: none;
-  }
-
-  .label {
-    font-weight: 600;
-  }
-
-  .value {
-    word-break: break-word;
-  }
-
-  .actions {
-    align-items: center;
-    display: flex;
     gap: 1rem;
+    padding: 0 0.5rem 1.5rem 0.5rem;
+
+    .image {
+      border-radius: 0.5rem 0.5rem 0 0;
+    }
+
+    .label {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    .measurements {
+      align-items: center;
+      display: flex;
+      gap: 1rem;
+      justify-content: space-evenly;
+    }
+
+    .measurement {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+      font-size: 0.8rem;
+      justify-content: center;
+    }
+
+    .battery, .signal {
+      width: 6rem;
+      height: 1.5rem;
+    }
+
+    .actions {
+      align-items: space-between;
+      display: flex;
+      gap: 1rem;
+    }
   }
 }

--- a/app/assets/css/layout.css
+++ b/app/assets/css/layout.css
@@ -1,6 +1,5 @@
 .site-page {
   align-content: start;
-  background-color: var(--site-color);
   display: grid;
   grid-template: auto 1fr auto / 1fr;
   grid-template-areas:

--- a/app/repositories/device.rb
+++ b/app/repositories/device.rb
@@ -6,7 +6,7 @@ module Terminus
     class Device < DB::Repository[:devices]
       commands :create, update: :by_pk, delete: :by_pk
 
-      def find(id) = devices.by_pk(id).one
+      def find(id) = (devices.by_pk(id).one if id)
 
       def find_by_api_key value
         devices.where { api_key.ilike "%#{value}%" }

--- a/app/templates/devices/_device.html.erb
+++ b/app/templates/devices/_device.html.erb
@@ -1,24 +1,46 @@
 <li id="<%= device.id %>" class="device">
-  <ul class="row">
-    <li class="value"><%= device.label %></li>
-    <li class="value"><%= device.friendly_id %></li>
-    <li class="value"><%= device.mac_address %></li>
-    <li class="value"><%= device.refresh_rate %></li>
-    <li class="actions">
-      <a href="/devices/<%= device.id %>/edit"
-         hx-get="/devices/<%= device.id %>/edit"
-         hx-target="closest .device"
-         hx-swap="outerHTML">
-        Edit
-      </a>
+  <%= render :image, uri: device.image_uri %>
 
-      <a href="/devices"
-         class="link-cancel"
-         hx-delete="/devices/<%= device.id %>"
-         hx-target="closest .device"
-         hx-swap="outerHTML">
-        Delete
-      </a>
-    </li>
-  </ul>
+  <h2 class="label"><%= device.label %></h2>
+
+  <div class="measurements">
+    <label class="measurement">
+      <%= tag.meter min: 0,
+                    low: 25,
+                    high: 85,
+                    optimum: 95,
+                    max: 100,
+                    value: device.battery_voltage,
+                    class: :battery %>
+      <%= format_number device.battery_voltage, precision: 0 %>% Battery
+    </label>
+
+    <label class="measurement">
+      <%= tag.meter min: 0,
+                    low: 25,
+                    high: 85,
+                    optimum: 95,
+                    max: 100,
+                    value: device.rssi,
+                    class: :signal %>
+      <%= device.rssi %>% Signal
+    </label>
+  </div>
+
+  <div class="actions">
+    <a href="/devices/<%= device.id %>/edit"
+       hx-get="/devices/<%= device.id %>/edit"
+       hx-target="closest .device"
+       hx-swap="outerHTML">
+      Edit
+    </a>
+
+    <a href="/devices"
+       class="link-cancel"
+       hx-delete="/devices/<%= device.id %>"
+       hx-target="closest .device"
+       hx-swap="outerHTML">
+      Delete
+    </a>
+  </div>
 </li>

--- a/app/templates/devices/_fields.html.erb
+++ b/app/templates/devices/_fields.html.erb
@@ -1,0 +1,52 @@
+<fieldset role="group" class="group">
+  <%= scope(:form_field, key: :label, errors:).render do %>
+    <label class="key">
+      Label
+      <%= tag.input name: "device[label]",
+                    value: field_for(:label, fields, device),
+                    class: :value,
+                    autocomplete: :label %>
+    </label>
+  <% end %>
+
+  <%= scope(:form_field, key: :friendly_id, errors:).render do %>
+    <label class="key">
+      Friendly ID
+      <%= tag.input name: "device[friendly_id]",
+                    value: field_for(:friendly_id, fields, device),
+                    class: :value,
+                    autocomplete: :friendly_id %>
+    </label>
+  <% end %>
+
+  <%= scope(:form_field, key: :mac_address, errors:).render do %>
+    <label class="key">
+      MAC Address
+      <%= tag.input name: "device[mac_address]",
+                    value: field_for(:mac_address, fields, device),
+                    class: :value,
+                    autocomplete: :mac_address %>
+    </label>
+  <% end %>
+
+  <%= scope(:form_field, key: :api_key, errors:).render do %>
+    <label class="key">
+      API Key
+      <%= tag.input name: "device[api_key]",
+                    type: :password,
+                    value: field_for(:api_key, fields, device),
+                    class: :value %>
+    </label>
+  <% end %>
+
+  <%= scope(:form_field, key: :refresh_rate, errors:).render do %>
+    <label class="key">
+      Refresh Rate
+      <%= tag.input name: "device[refresh_rate]",
+                    value: field_for(:refresh_rate, fields, device),
+                    class: :value,
+                    autocomplete: :refresh_rate %>
+    </label>
+  <% end %>
+</fieldset>
+

--- a/app/templates/devices/_image.html.erb
+++ b/app/templates/devices/_image.html.erb
@@ -1,0 +1,1 @@
+<%= tag.img src: uri, alt: "Screen", class: "image", width: 320, height: 192, loading: :lazy %>

--- a/app/templates/devices/edit.html.erb
+++ b/app/templates/devices/edit.html.erb
@@ -1,71 +1,12 @@
 <li class="device">
-  <form action="/devices" method="put" class="site-form">
-    <fieldset role="group" class="group">
-      <label class="label">
-        Label
-        <input name="device[label]"
-               value="<%= device.label %>"
-               class="value"
-               autocomplete="label">
-      </label>
+  <%= render :image, uri: device.image_uri %>
 
-      <label class="label">
-        Friendly ID
-        <input name="device[friendly_id]"
-               value="<%= device.friendly_id %>"
-               class="value"
-               autocomplete="friendly_id">
-      </label>
-
-      <label class="label">
-        MAC Address
-        <input name="device[mac_address]"
-               value="<%= device.mac_address %>"
-               class="value"
-               autocomplete="mac_address">
-      </label>
-
-      <label class="label">
-        API Key
-        <input name="device[api_key]"
-               type="password"
-               value="<%= device.api_key %>"
-               class="value">
-      </label>
-
-      <label class="label">
-        Refresh Rate
-        <input name="device[refresh_rate]"
-               value="<%= device.refresh_rate %>"
-               class="value"
-               autocomplete="refresh_rate">
-      </label>
-    </fieldset>
-
-    <% if errors.any? %>
-      <ul class="site-errors">
-        <% errors.each do |attribute, message| %>
-          <li><%= "#{attribute} #{message.first}" %></li>
-        <% end %>
-      </ul>
-    <% end %>
+  <form action="/devices" method="put" class="page-form">
+    <%= render :fields, device:, fields: fields.value, errors: %>
 
     <div class="form-actions">
-      <input type="submit"
-             value="Save"
-             class="accept"
-             hx-put="/devices/<%= device.id %>"
-             hx-trigger="click"
-             hx-target="closest .device"
-             hx-swap="outerHTML swap:0s">
-
-      <input type="button"
-             value="Cancel"
-             class="decline"
-             hx-get="/devices/<%= device.id %>"
-             hx-trigger="click"
-             hx-target="closest .device"
-             hx-swap="outerHTML swap:0s">
+      <%= device_save :put, "/devices/#{device.id}" %>
+      <%= device_form_cancel "/devices/#{device.id}" %>
     </div>
   </form>
 </li>

--- a/app/templates/devices/index.html.erb
+++ b/app/templates/devices/index.html.erb
@@ -1,26 +1,31 @@
-<section class="page page-devices">
-  <h1>Devices</h1>
+<section class="page-devices">
+  <header class="page-header">
+    <h1 class="label">Devices</h1>
 
-  <ul class="columns">
-    <li class="label">Label</li>
-    <li class="label">Friendly ID</li>
-    <li class="label">MAC Address</li>
-    <li class="label">Refresh Rate</li>
-    <li class="label">Actions</li>
-  </ul>
+    <div class="actions">
+      <button class="popover-trigger" popovertarget="popover-shortcuts">⌨️</button>
+
+      <dialog id="popover-shortcuts" class="popover-content" popover="auto">
+        <button class="close" popovertarget="popover-shortcuts" popovertargetaction="hide">
+          <span aria-hidden=true>❌</span>
+          <span class="screen_reader">Close</span>
+        </button>
+
+        <h3 class="label">Keyboard Shortcuts</h3>
+
+        <ul>
+          <li><kbd>CONTROL + n</kbd>: New device.</li>
+          <li><kbd>CONTROL + s</kbd>: Save device (when within form).</li>
+        </ul>
+      </dialog>
+
+      <%= device_new %>
+    </div>
+  </header>
 
   <ul class="devices">
     <% devices.each do |device| %>
       <%= device.render :device %>
     <% end %>
   </ul>
-
-  <a href="/devices/new"
-     class="button button-new"
-     hx-get="/devices/new"
-     hx-trigger="click, keyup[ctrlKey&&key=='n'] from:body"
-     hx-target=".devices"
-     hx-swap="beforeend settle:0.1s">
-    New
-  </a>
 </section>

--- a/app/templates/devices/new.html.erb
+++ b/app/templates/devices/new.html.erb
@@ -1,60 +1,12 @@
 <li class="device" hx-ext="remove">
-  <form action="/devices" method="post" class="site-form">
-    <fieldset role="group" class="group">
-      <label class="label">
-        Label
-        <input name="device[label]"
-               class="value"
-               autocomplete="label">
-      </label>
+  <%= render :image, uri: "/assets/images/setup/logo.bmp" %>
 
-      <label class="label">
-        Friendly ID
-        <input name="device[friendly_id]"
-               class="value"
-               autocomplete="friendly_id">
-      </label>
-
-      <label class="label">
-        MAC Address
-        <input name="device[mac_address]"
-               class="value"
-               autocomplete="mac_address">
-      </label>
-
-      <label class="label">
-        API Key
-        <input name="device[api_key]"
-               type="password"
-               class="value">
-      </label>
-
-      <label class="label">
-        Refresh Rate
-        <input name="device[refresh_rate]"
-               class="value"
-               autocomplete="refresh_rate">
-      </label>
-    </fieldset>
-
-    <% if errors.any? %>
-      <ul class="site-errors">
-        <% errors.each do |attribute, message| %>
-          <li><%= "#{attribute} #{message.first}" %></li>
-        <% end %>
-      </ul>
-    <% end %>
+  <form action="/devices" method="post" class="page-form">
+    <%= render :fields, device:, fields: fields.value, errors: %>
 
     <div class="form-actions">
-      <input type="submit"
-             value="Save"
-             class="accept"
-             hx-post="/devices"
-             hx-trigger="click"
-             hx-target="closest .device"
-             hx-swap="outerHTML swap:0s">
-
-      <input type="button" value="Cancel" class="decline" data-remove="true">
+      <%= device_save :post, "/devices" %>
+      <%= device_form_remove %>
     </div>
   </form>
 </li>

--- a/app/templates/shared/_form_field.html.erb
+++ b/app/templates/shared/_form_field.html.erb
@@ -1,0 +1,6 @@
+<p class="<%= toggle_error %>">
+  <%= yield %>
+  <% unless error_message.empty? %>
+    <em class="message"><%= error_message %></em>
+  <% end %>
+</p>

--- a/app/views/devices/edit.rb
+++ b/app/views/devices/edit.rb
@@ -6,7 +6,8 @@ module Terminus
       # The edit view.
       class Edit < Terminus::View
         expose :device
-        expose :errors
+        expose :fields, default: Dry::Core::EMPTY_HASH
+        expose :errors, default: Dry::Core::EMPTY_HASH
       end
     end
   end

--- a/app/views/devices/new.rb
+++ b/app/views/devices/new.rb
@@ -6,7 +6,8 @@ module Terminus
       # The new view.
       class New < Terminus::View
         expose :device
-        expose :errors
+        expose :fields, default: Dry::Core::EMPTY_HASH
+        expose :errors, default: Dry::Core::EMPTY_HASH
       end
     end
   end

--- a/app/views/helpers.rb
+++ b/app/views/helpers.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "htmx"
+require "refinements/hash"
+
+module Terminus
+  module Views
+    # The view helpers.
+    module Helpers
+      using Refinements::Hash
+
+      def search path
+        tag.input(
+          id: "search",
+          type: "search",
+          name: "query",
+          value: "",
+          **HTMX[
+            get: path,
+            trigger: "search, keyup delay:200ms changed",
+            target: "next .tasks",
+            push_url: true,
+            indicator: ".loader"
+          ]
+        )
+      end
+
+      # :reek:UtilityFunction
+      def field_for key, attributes, record = nil
+        return attributes[key] unless record
+
+        attributes.fetch_value key, record.public_send(key)
+      end
+
+      def device_new
+        path = routes.path :devices_new
+
+        link_to(
+          "New",
+          path,
+          class: "button button-new",
+          **HTMX[
+            get: path,
+            trigger: "click, keyup[ctrlKey&&key=='n'] from:body",
+            target: ".devices",
+            swap: "beforeend settle:0.1s"
+          ]
+        )
+      end
+
+      def device_save verb, path
+        tag.input(
+          type: :submit,
+          value: "Save",
+          class: :accept,
+          **HTMX[
+            verb => path,
+            trigger: "click, keyup[ctrlKey&&key=='s'] from:closest .device",
+            target: "closest .device",
+            swap: "outerHTML swap:0s"
+          ]
+        )
+      end
+
+      def device_form_cancel path
+        tag.input(
+          type: :button,
+          value: "Cancel",
+          class: :decline,
+          **HTMX[
+            get: path,
+            trigger: "click",
+            target: "closest .device",
+            swap: "outerHTML swap:0s"
+          ]
+        )
+      end
+
+      def device_form_remove
+        tag.input type: :button, value: "Cancel", class: :decline, data: {remove: true}
+      end
+    end
+  end
+end

--- a/app/views/parts/device.rb
+++ b/app/views/parts/device.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "hanami/view"
+require "initable"
+
+module Terminus
+  module Views
+    module Parts
+      # The device presenter.
+      class Device < Hanami::View::Part
+        include Initable[fetcher: proc { Terminus::Images::Fetcher.new }]
+        include Deps[:settings]
+
+        def image_uri
+          fetcher.call(
+            Pathname(settings.images_root).join("generated"),
+            images_uri: "https://localhost:2443/assets/images"
+          )[:image_url]
+        end
+      end
+    end
+  end
+end

--- a/app/views/scopes/form_field.rb
+++ b/app/views/scopes/form_field.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "dry/core"
+require "refinements/array"
+
+module Terminus
+  module Views
+    module Scopes
+      # Groups form label and input together as a single form field.
+      class FormField < Hanami::View::Scope
+        using Refinements::Array
+
+        def toggle_error kind = "form-field"
+          errors.fetch(key, Dry::Core::EMPTY_ARRAY).any? ? [kind, "error"].compact.join(" ") : kind
+        end
+
+        def error_message
+          return Dry::Core::EMPTY_STRING unless locals.key? :errors
+          return Dry::Core::EMPTY_STRING unless errors.key? key
+
+          errors[key].to_sentence
+        end
+
+        def render(path = "shared/form_field") = super
+      end
+    end
+  end
+end

--- a/spec/app/actions/devices/update_spec.rb
+++ b/spec/app/actions/devices/update_spec.rb
@@ -10,13 +10,18 @@ RSpec.describe Terminus::Actions::Devices::Update, :db do
 
     it "answers success when there are no validation errors" do
       device
-      response = action.call id: device.id, device: {label: "Test Update"}
+      response = action.call id: device.id, device: {label: "Test"}
       expect(response.status).to eq(200)
     end
 
     it "answers errors when fields are missing" do
       response = action.call id: device.id, device: {label: ""}
-      expect(response.body.to_s).to include("label must be filled")
+      expect(response.body.to_s).to include("must be filled")
+    end
+
+    it "answers unprocessable entity for unknown device" do
+      response = action.call id: 99
+      expect(response.status).to eq(422)
     end
   end
 end

--- a/spec/app/repositories/device_spec.rb
+++ b/spec/app/repositories/device_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Terminus::Repositories::Device, :db do
     it "answers nil for unknown ID" do
       expect(repository.find(13)).to be(nil)
     end
+
+    it "answers nil for nil ID" do
+      expect(repository.find(nil)).to be(nil)
+    end
   end
 
   describe "#find_by_api_key" do

--- a/spec/app/views/parts/device_spec.rb
+++ b/spec/app/views/parts/device_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Views::Parts::Device, :db do
+  using Refinements::Pathname
+
+  subject(:part) { described_class.new settings:, value: device, rendering: view.new.rendering }
+
+  let(:settings) { Hanami.app[:settings] }
+  let(:device) { Factory[:device] }
+
+  let :view do
+    Class.new Hanami::View do
+      config.paths = [Hanami.app.root.join("app/templates")]
+      config.template = "n/a"
+    end
+  end
+
+  include_context "with temporary directory"
+
+  describe "#image_uri" do
+    before do
+      allow(settings).to receive(:images_root).and_return(temp_dir)
+
+      SPEC_ROOT.join("support/fixtures/test.bmp")
+               .copy temp_dir.join("generated/test.bmp").make_ancestors
+    end
+
+    it "answers URI" do
+      expect(part.image_uri).to eq("https://localhost:2443/assets/images/generated/test.bmp")
+    end
+  end
+end

--- a/spec/app/views/scopes/form_field_spec.rb
+++ b/spec/app/views/scopes/form_field_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Views::Scopes::FormField do
+  subject :scope do
+    described_class.new locals: {key: :label, errors:}, rendering: view.new.rendering
+  end
+
+  let(:errors) { {label: %w[invalid missing]} }
+
+  let :view do
+    Class.new Hanami::View do
+      config.paths = [Hanami.app.root.join("app/templates")]
+      config.template = "n/a"
+    end
+  end
+
+  describe "#toggle_error" do
+    it "answers default kind without errors" do
+      errors.clear
+      expect(scope.toggle_error).to eq("form-field")
+    end
+
+    it "answers default kind for key with no errors" do
+      scope = described_class.new locals: {key: :clean, errors:}, rendering: view.new.rendering
+      expect(scope.toggle_error).to eq("form-field")
+    end
+
+    it "answers default kind with error class with errors" do
+      expect(scope.toggle_error).to eq("form-field error")
+    end
+
+    it "answers custom kind with errors" do
+      expect(scope.toggle_error("test")).to eq("test error")
+    end
+  end
+
+  describe "#error_message" do
+    it "answers empty string when given no errors" do
+      errors.clear
+      expect(scope.error_message).to eq("")
+    end
+
+    it "answers empty string with missing local" do
+      scope = described_class.new rendering: view.new.rendering
+      expect(scope.error_message).to eq("")
+    end
+
+    it "answers message when given errors" do
+      expect(scope.error_message).to eq("invalid and missing")
+    end
+  end
+
+  describe "#render" do
+    it "renders without errors" do
+      errors.clear
+      content = scope.render { "Test" }
+
+      expect(content).to eq(<<~CONTENT)
+        <p class="form-field">
+          Test
+        </p>
+      CONTENT
+    end
+
+    it "renders with errors" do
+      content = scope.render { "Test" }
+
+      expect(content).to eq(<<~CONTENT)
+        <p class="form-field error">
+          Test
+            <em class="message">invalid and missing</em>
+        </p>
+      CONTENT
+    end
+  end
+end


### PR DESCRIPTION
## Overview

This completes functionality for adding/managing devices so you can quickly add, update, delete devices as needed. This also folds in support for displaying battery and signal strength (which isn't fully functional at the moment but will be soon).

## Screenshots/Screencasts

The following demonstrates the new UI for devices. CSS View Transitions are leaned on heavily for smooth fade in/out effects. Error handling is much better now too. ...and there are keyboard shortcuts you can use.

https://github.com/user-attachments/assets/3d41cbd5-6a50-47fb-94a1-d7ddae3d37ad

## Details

- See commits for details.