### PR TITLE
Added device signal, battery, width, and height information

### DIFF
--- a/.config/rubocop/config.yml
+++ b/.config/rubocop/config.yml
@@ -3,7 +3,14 @@ inherit_gem:
 
 plugins: rubocop-sequel
 
+Metrics/CyclomaticComplexity:
+  AllowedMethods:
+    - battery_percentage
+    - signal_percentage
 Metrics/MethodLength:
+  AllowedMethods:
+    - battery_percentage
+    - signal_percentage
   Exclude:
     - app/views/helpers.rb
 RSpec/SpecFilePathFormat:

--- a/.reek.yml
+++ b/.reek.yml
@@ -14,3 +14,5 @@ detectors:
     exclude:
       - Terminus::Images::Greyscaler#convert
       - Terminus::Images::Screensaver#save
+      - Terminus::Views::Parts::Device#battery_percentage
+      - Terminus::Views::Parts::Device#signal_percentage

--- a/app/templates/devices/_device.html.erb
+++ b/app/templates/devices/_device.html.erb
@@ -10,9 +10,9 @@
                     high: 85,
                     optimum: 95,
                     max: 100,
-                    value: device.battery_voltage,
+                    value: device.battery,
                     class: :battery %>
-      <%= format_number device.battery_voltage, precision: 0 %>% Battery
+      <%= format_number device.battery, precision: 0 %>% Battery
     </label>
 
     <label class="measurement">
@@ -21,9 +21,9 @@
                     high: 85,
                     optimum: 95,
                     max: 100,
-                    value: device.rssi,
+                    value: device.signal,
                     class: :signal %>
-      <%= device.rssi %>% Signal
+      <%= device.signal %>% Signal
     </label>
   </div>
 

--- a/app/templates/devices/_device.html.erb
+++ b/app/templates/devices/_device.html.erb
@@ -6,24 +6,24 @@
   <div class="measurements">
     <label class="measurement">
       <%= tag.meter min: 0,
-                    low: 25,
-                    high: 85,
+                    low: 10,
+                    high: 90,
                     optimum: 95,
                     max: 100,
-                    value: device.battery,
+                    value: device.battery_percentage,
                     class: :battery %>
-      <%= format_number device.battery, precision: 0 %>% Battery
+      <%= format_number device.battery_percentage, precision: 0 %>% Battery
     </label>
 
     <label class="measurement">
       <%= tag.meter min: 0,
-                    low: 25,
-                    high: 85,
+                    low: 10,
+                    high: 90,
                     optimum: 95,
                     max: 100,
-                    value: device.signal,
+                    value: device.signal_percentage,
                     class: :signal %>
-      <%= device.signal %>% Signal
+      <%= device.signal_percentage %>% Signal
     </label>
   </div>
 

--- a/app/views/parts/device.rb
+++ b/app/views/parts/device.rb
@@ -11,6 +11,38 @@ module Terminus
         include Initable[fetcher: proc { Terminus::Images::Fetcher.new }]
         include Deps[:settings]
 
+        def battery_percentage
+          case battery
+            when 0 then 0
+            when ..0.45 then 10
+            when 0.46..0.9 then 20
+            when 1.0..1.35 then 30
+            when 1.36..1.8 then 40
+            when 1.81..2.25 then 50
+            when 2.26..2.7 then 60
+            when 2.71..3.15 then 70
+            when 3.16..3.6 then 80
+            when 3.61..4.05 then 90
+            else 100
+          end
+        end
+
+        def signal_percentage
+          case signal
+            when 0 then 0
+            when ..-91 then 10
+            when -90..-81 then 20
+            when -80..-71 then 30
+            when -70..-67 then 40
+            when -66..-62 then 50
+            when -61..-57 then 60
+            when -56..-52 then 70
+            when -51..-47 then 80
+            when -46..-40 then 90
+            else 100
+          end
+        end
+
         def image_uri
           fetcher.call(
             Pathname(settings.images_root).join("generated"),

--- a/config/db/migrate/20250318091514_alter_device_battery_and_signal.rb
+++ b/config/db/migrate/20250318091514_alter_device_battery_and_signal.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+ROM::SQL.migration do
+  change do
+    alter_table :devices do
+      rename_column :battery_voltage, :battery
+      rename_column :rssi, :signal
+    end
+  end
+end

--- a/config/db/migrate/20250318092424_add_device_width_and_height.rb
+++ b/config/db/migrate/20250318092424_add_device_width_and_height.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+ROM::SQL.migration do
+  change do
+    alter_table :devices do
+      add_column :width, :integer, null: false, default: 0
+      add_column :height, :integer, null: false, default: 0
+    end
+  end
+end

--- a/config/db/structure.sql
+++ b/config/db/structure.sql
@@ -12,8 +12,11 @@ CREATE TABLE `devices`(
   `refresh_rate` integer DEFAULT(900) NOT NULL,
   `setup_at` timestamp,
   `created_at` timestamp DEFAULT(datetime(CURRENT_TIMESTAMP, 'localtime')) NOT NULL,
-  `updated_at` timestamp DEFAULT(datetime(CURRENT_TIMESTAMP, 'localtime')) NOT NULL
+  `updated_at` timestamp DEFAULT(datetime(CURRENT_TIMESTAMP, 'localtime')) NOT NULL,
+  `width` integer DEFAULT(0) NOT NULL,
+  `height` integer DEFAULT(0) NOT NULL
 );
 INSERT INTO schema_migrations (filename) VALUES
 ('20250305150912_create_devices.rb'),
-('20250318091514_alter_device_battery_and_signal.rb');
+('20250318091514_alter_device_battery_and_signal.rb'),
+('20250318092424_add_device_width_and_height.rb');

--- a/config/db/structure.sql
+++ b/config/db/structure.sql
@@ -7,12 +7,13 @@ CREATE TABLE `devices`(
   `api_key` string,
   `firmware_version` string,
   `firmware_beta` boolean DEFAULT(0) NOT NULL,
-  `rssi` integer DEFAULT(0) NOT NULL,
-  `battery_voltage` float DEFAULT(0) NOT NULL,
+  "signal" integer DEFAULT(0) NOT NULL,
+  "battery" float DEFAULT(0) NOT NULL,
   `refresh_rate` integer DEFAULT(900) NOT NULL,
   `setup_at` timestamp,
   `created_at` timestamp DEFAULT(datetime(CURRENT_TIMESTAMP, 'localtime')) NOT NULL,
   `updated_at` timestamp DEFAULT(datetime(CURRENT_TIMESTAMP, 'localtime')) NOT NULL
 );
 INSERT INTO schema_migrations (filename) VALUES
-('20250305150912_create_devices.rb');
+('20250305150912_create_devices.rb'),
+('20250318091514_alter_device_battery_and_signal.rb');

--- a/lib/terminus/http/headers/model.rb
+++ b/lib/terminus/http/headers/model.rb
@@ -5,12 +5,12 @@ module Terminus
     module Headers
       KEY_MAP = {
         HTTP_ACCESS_TOKEN: :access_token,
-        HTTP_BATTERY_VOLTAGE: :battery_voltage,
+        HTTP_BATTERY_VOLTAGE: :battery,
         HTTP_FW_VERSION: :firmware_version,
         HTTP_HOST: :host,
         HTTP_ID: :mac_address,
         HTTP_REFRESH_RATE: :refresh_rate,
-        HTTP_RSSI: :rssi,
+        HTTP_RSSI: :signal,
         HTTP_USER_AGENT: :user_agent,
         HTTP_WIDTH: :width,
         HTTP_HEIGHT: :height
@@ -20,7 +20,9 @@ module Terminus
       Model = Data.define(*KEY_MAP.values) do
         def self.for(headers, key_map: KEY_MAP) = new(**headers.transform_keys(key_map))
 
-        def device_attributes = {battery_voltage:, firmware_version: firmware_version.to_s, rssi:}
+        def device_attributes
+          {battery:, firmware_version: firmware_version.to_s, signal:, width:, height:}
+        end
       end
     end
   end

--- a/spec/app/aspects/synchronizers/device_spec.rb
+++ b/spec/app/aspects/synchronizers/device_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe Terminus::Aspects::Synchronizers::Device, :db do
 
       expect(updater.call(firmware_headers)).to match(
         Success(
-          have_attributes(rssi: -54, firmware_version: "1.2.3", battery_voltage: 4.74)
+          have_attributes(
+            battery: 4.74,
+            firmware_version: "1.2.3",
+            signal: -54,
+            width: 800,
+            height: 480
+          )
         )
       )
     end

--- a/spec/app/views/parts/device_spec.rb
+++ b/spec/app/views/parts/device_spec.rb
@@ -31,4 +31,133 @@ RSpec.describe Terminus::Views::Parts::Device, :db do
       expect(part.image_uri).to eq("https://localhost:2443/assets/images/generated/test.bmp")
     end
   end
+
+  describe "#battery_percentage" do
+    it "answers zero when zero" do
+      allow(device).to receive(:battery).and_return(0)
+      expect(part.battery_percentage).to eq(0)
+    end
+
+    it "answers ten percent when extremely low" do
+      allow(device).to receive(:battery).and_return(0.1)
+      expect(part.battery_percentage).to eq(10)
+    end
+
+    it "answers ten percent when in range" do
+      allow(device).to receive(:battery).and_return(0.25)
+      expect(part.battery_percentage).to eq(10)
+    end
+
+    it "answers twenty percent when in range" do
+      allow(device).to receive(:battery).and_return(0.75)
+      expect(part.battery_percentage).to eq(20)
+    end
+
+    it "answers thirty percent when in range" do
+      allow(device).to receive(:battery).and_return(1.15)
+      expect(part.battery_percentage).to eq(30)
+    end
+
+    it "answers fourty percent when in range" do
+      allow(device).to receive(:battery).and_return(1.5)
+      expect(part.battery_percentage).to eq(40)
+    end
+
+    it "answers fifty percent when in range" do
+      allow(device).to receive(:battery).and_return(2.0)
+      expect(part.battery_percentage).to eq(50)
+    end
+
+    it "answers sixty percent when in range" do
+      allow(device).to receive(:battery).and_return(2.5)
+      expect(part.battery_percentage).to eq(60)
+    end
+
+    it "answers seventy percent when in range" do
+      allow(device).to receive(:battery).and_return(3.0)
+      expect(part.battery_percentage).to eq(70)
+    end
+
+    it "answers eighty percent when in range" do
+      allow(device).to receive(:battery).and_return(3.3)
+      expect(part.battery_percentage).to eq(80)
+    end
+
+    it "answers ninety percent when in range" do
+      allow(device).to receive(:battery).and_return(3.9)
+      expect(part.battery_percentage).to eq(90)
+    end
+
+    it "answers one hundred percent when in range" do
+      allow(device).to receive(:battery).and_return(4.8)
+      expect(part.battery_percentage).to eq(100)
+    end
+
+    it "answers one hundred percent beyond high end range" do
+      allow(device).to receive(:battery).and_return(4.5)
+      expect(part.battery_percentage).to eq(100)
+    end
+  end
+
+  describe "#signal_percentage" do
+    it "answers zero when zero" do
+      allow(device).to receive(:signal).and_return(0)
+      expect(part.battery_percentage).to eq(0)
+    end
+
+    it "answers ten percent when extremely low" do
+      allow(device).to receive(:signal).and_return(-100)
+      expect(part.signal_percentage).to eq(10)
+    end
+
+    it "answers ten percent when in range" do
+      allow(device).to receive(:signal).and_return(-95)
+      expect(part.signal_percentage).to eq(10)
+    end
+
+    it "answers twenty percent when in range" do
+      allow(device).to receive(:signal).and_return(-85)
+      expect(part.signal_percentage).to eq(20)
+    end
+
+    it "answers thirty percent when in range" do
+      allow(device).to receive(:signal).and_return(-75)
+      expect(part.signal_percentage).to eq(30)
+    end
+
+    it "answers fourty percent when in range" do
+      allow(device).to receive(:signal).and_return(-69)
+      expect(part.signal_percentage).to eq(40)
+    end
+
+    it "answers fifty percent when in range" do
+      allow(device).to receive(:signal).and_return(-65)
+      expect(part.signal_percentage).to eq(50)
+    end
+
+    it "answers sixty percent when in range" do
+      allow(device).to receive(:signal).and_return(-59)
+      expect(part.signal_percentage).to eq(60)
+    end
+
+    it "answers seventy percent when in range" do
+      allow(device).to receive(:signal).and_return(-54)
+      expect(part.signal_percentage).to eq(70)
+    end
+
+    it "answers eighty percent when in range" do
+      allow(device).to receive(:signal).and_return(-49)
+      expect(part.signal_percentage).to eq(80)
+    end
+
+    it "answers ninety percent when in range" do
+      allow(device).to receive(:signal).and_return(-45)
+      expect(part.signal_percentage).to eq(90)
+    end
+
+    it "answers one hundred percent when in range" do
+      allow(device).to receive(:signal).and_return(-25)
+      expect(part.signal_percentage).to eq(100)
+    end
+  end
 end

--- a/spec/lib/terminus/http/headers/model_spec.rb
+++ b/spec/lib/terminus/http/headers/model_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Terminus::HTTP::Headers::Model do
       mac_address: "A1:B2:C3:D4:E5:F6",
       access_token: "abc123",
       refresh_rate: 25,
-      battery_voltage: 4.74,
+      battery: 4.74,
       firmware_version: Version("1.2.3"),
-      rssi: 50,
+      signal: -40,
       width: 800,
       height: 480
     ]
@@ -35,9 +35,9 @@ RSpec.describe Terminus::HTTP::Headers::Model do
           mac_address: "A1:B2:C3:D4:E5:F6",
           access_token: "abc123",
           refresh_rate: "25",
-          battery_voltage: "4.74",
+          battery: "4.74",
           firmware_version: "1.2.3",
-          rssi: "-54",
+          signal: "-54",
           width: "800",
           height: "480"
         ]
@@ -48,9 +48,11 @@ RSpec.describe Terminus::HTTP::Headers::Model do
   describe "#device_attributes" do
     it "answers device attributes" do
       expect(record.device_attributes).to eq(
-        battery_voltage: 4.74,
+        battery: 4.74,
         firmware_version: "1.2.3",
-        rssi: 50
+        signal: -40,
+        width: 800,
+        height: 480
       )
     end
   end

--- a/spec/lib/terminus/http/headers/parser_spec.rb
+++ b/spec/lib/terminus/http/headers/parser_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Terminus::HTTP::Headers::Parser do
           mac_address: "A1:B2:C3:D4:E5:F6",
           access_token: "abc123",
           refresh_rate: 25,
-          battery_voltage: 4.74,
+          battery: 4.74,
           firmware_version: Version("1.2.3"),
-          rssi: -54,
+          signal: -54,
           width: 800,
           height: 480
         ]


### PR DESCRIPTION
## Overview

The following builds upon the work from yesterday where now get accurate signal and battery levels. ★

## Screenshots/Screencasts

![2025-03-18_11-33-44-Brave Browser](https://github.com/user-attachments/assets/7dce8a14-1112-446f-97a7-88c0bd612ff1)

## Details

- See commits for details.