### PR TITLE
Added branding

### DIFF
--- a/app/assets/css/layout.css
+++ b/app/assets/css/layout.css
@@ -22,12 +22,16 @@
   }
 
   .list {
+    align-items: center;
+    display: flex;
     list-style: none;
     margin: 0;
     padding: 0;
+    gap: 1rem;
   }
 
   .link {
+    display: flex;
     color: var(--site-white);
   }
 }

--- a/app/assets/images/icon.svg
+++ b/app/assets/images/icon.svg
@@ -1,4 +1,0 @@
-<svg width="1600px" height="1600px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g style="">  <ellipse cx="800.000000" cy="800.000000" rx="757.000000" ry="754.000000" stroke-linejoin="round" style="fill: rgba(220, 54, 16, 1.000000); stroke-width: 75.000000px; stroke: rgba(200, 48, 33, 1.000000); " fill="#dc3610" stroke="#c83021" stroke-width="75.000000"  />
-</g><g style="">  <ellipse cx="799.500000" cy="800.500000" rx="362.500000" ry="362.500000" stroke-linejoin="round" style="fill: none; stroke-width: 75.000000px; stroke: rgba(255, 255, 255, 1.000000); " fill="none" stroke="#ffffff" stroke-width="75.000000"  />
-</g></svg>

--- a/app/assets/images/logo/black.svg
+++ b/app/assets/images/logo/black.svg
@@ -1,0 +1,9 @@
+<svg width="160" height="162" viewBox="0 0 160 162" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M43.2327 11.3438L85.6173 27.238L77.7464 48.227L35.3618 32.3328L43.2327 11.3438Z" fill="black"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M111.192 6.15371L125.192 49.2012L103.875 56.1339L89.8749 13.0865L111.192 6.15371Z" fill="black"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M157.609 56.0681L132.681 93.8532L113.97 81.5091L138.897 43.724L157.609 56.0681Z" fill="black"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M147.532 123.466L102.448 127.536L100.433 105.21L145.516 101.14L147.532 123.466Z" fill="black"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88.5479 157.612L57.2569 124.902L73.4552 109.407L104.746 142.117L88.5479 157.612Z" fill="black"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M25.0725 132.803L31.1368 87.9443L53.351 90.9474L47.2868 135.806L25.0725 132.803Z" fill="black"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.90754 67.6822L43.7605 44.4545L55.263 63.6947L16.41 86.9224L4.90754 67.6822Z" fill="black"/>
+</svg>

--- a/app/assets/images/logo/salmon.svg
+++ b/app/assets/images/logo/salmon.svg
@@ -1,0 +1,9 @@
+<svg width="160" height="162" viewBox="0 0 160 162" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M43.2327 11.3438L85.6173 27.238L77.7464 48.227L35.3618 32.3328L43.2327 11.3438Z" fill="#F8654B"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M111.192 6.15371L125.192 49.2012L103.875 56.1339L89.8749 13.0865L111.192 6.15371Z" fill="#F8654B"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M157.609 56.0681L132.681 93.8532L113.97 81.5091L138.897 43.724L157.609 56.0681Z" fill="#F8654B"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M147.532 123.466L102.448 127.536L100.433 105.21L145.516 101.14L147.532 123.466Z" fill="#F8654B"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88.5479 157.612L57.257 124.902L73.4552 109.407L104.746 142.117L88.5479 157.612Z" fill="#F8654B"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M25.0725 132.803L31.1368 87.9443L53.351 90.9474L47.2868 135.806L25.0725 132.803Z" fill="#F8654B"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.90754 67.6822L43.7605 44.4545L55.263 63.6947L16.41 86.9224L4.90754 67.6822Z" fill="#F8654B"/>
+</svg>

--- a/app/assets/images/logo/white.svg
+++ b/app/assets/images/logo/white.svg
@@ -1,0 +1,9 @@
+<svg width="160" height="162" viewBox="0 0 160 162" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M43.2327 11.3438L85.6173 27.238L77.7464 48.227L35.3618 32.3328L43.2327 11.3438Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M111.192 6.15371L125.192 49.2012L103.875 56.1339L89.8749 13.0865L111.192 6.15371Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M157.609 56.0681L132.681 93.8532L113.97 81.5091L138.897 43.724L157.609 56.0681Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M147.532 123.466L102.448 127.536L100.433 105.21L145.516 101.14L147.532 123.466Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88.5479 157.612L57.2569 124.902L73.4552 109.407L104.746 142.117L88.5479 157.612Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M25.0725 132.803L31.1368 87.9443L53.351 90.9474L47.2868 135.806L25.0725 132.803Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.90754 67.6822L43.7605 44.4545L55.263 63.6947L16.41 86.9224L4.90754 67.6822Z" fill="white"/>
+</svg>

--- a/app/assets/pwa/manifest.webmanifest
+++ b/app/assets/pwa/manifest.webmanifest
@@ -4,14 +4,9 @@
   "description": "A TRMNL server.",
   "icons": [
     {
-      "src": "https://alchemists.io/images/projects/hanamismith/icons/small.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "https://alchemists.io/images/projects/hanamismith/icons/large.png",
-      "type": "image/png",
-      "sizes": "512x512"
+      "src": "https://usetrmnl.com/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
     }
   ],
   "display": "standalone",

--- a/app/templates/layouts/app.html.erb
+++ b/app/templates/layouts/app.html.erb
@@ -20,12 +20,14 @@
 
     <%= tag.link title: "Terminus: Icon",
                  rel: :icon,
-                 href: assets["icon.svg"],
+                 href: assets["logo/salmon.svg"],
                  type: "image/svg+xml" %>
+
     <link title="Terminus: Apple Icon"
           rel="apple-touch-icon"
           href="https://usetrmnl.com/images/brand/icon--brand.png"
           type="image/png">
+
     <%= tag.link title: "Terminus: Manifest",
                  rel: :manifest,
                  href: assets["manifest.webmanifest"] %>

--- a/app/templates/shared/_header.html.erb
+++ b/app/templates/shared/_header.html.erb
@@ -1,5 +1,10 @@
 <nav class="navigation">
   <ul class="list">
+    <li>
+      <a href="https://usetrmnl.com" class="link">
+        <%= tag.img src: assets["logo/salmon.svg"], alt: "Logo", width: 30, height: 30 %>
+      </a>
+    </li>
     <li><a href="/" class="link">Terminus</a></li>
   </ul>
 

--- a/config/slices/home.rb
+++ b/config/slices/home.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Home
-  # The home slice configuration.
-  class Slice < Hanami::Slice
-    import keys: ["assets"], from: Hanami.app.container, as: :app
-  end
-end

--- a/slices/health/templates/layouts/app.html.erb
+++ b/slices/health/templates/layouts/app.html.erb
@@ -12,17 +12,19 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
 
-    <link title="Terminus: Favorite Icon"
+    <link title="Terminus: Favicon"
           rel="icon"
-          href="https://alchemists.io/images/projects/hanamismith/icons/favicon.ico"
+          href="https://usetrmnl.com/favicon.ico"
           sizes="32x32">
-    <%= favicon_tag app_assets["icon.svg"],
+
+    <%= favicon_tag app_assets["logo/salmon.svg"],
                     title: "Terminus: Icon",
                     rel: :icon,
                     type: "image/svg+xml" %>
+
     <link title="Terminus: Apple Icon"
           rel="apple-touch-icon"
-          href="https://alchemists.io/images/projects/hanamismith/icons/apple.png"
+          href="https://usetrmnl.com/images/brand/icon--brand.png"
           type="image/png">
   </head>
 


### PR DESCRIPTION
## Overview

The following cleans up the branding for the server and ensures this app looks good when installed as a PWA. ★

## Screenshots/Screencasts

<details>
  <summary>iOS PWA App Icon</summary>

![icon](https://github.com/user-attachments/assets/13833ce8-93d5-4aab-8889-e5944d8954f0)
</details>

<details>
  <summary>Installed iOS PWA app</summary>

![app](https://github.com/user-attachments/assets/6072c9ef-ae7f-4581-b172-9fc30fd1e40d)
</details>

## Details

- See commits for details.