### PR TITLE
Added dashboard and automatic IP resolution

### DIFF
--- a/.config/rubocop/config.yml
+++ b/.config/rubocop/config.yml
@@ -16,3 +16,6 @@ Metrics/MethodLength:
 RSpec/SpecFilePathFormat:
   CustomTransform:
     Terminus: ""
+Style/IpAddresses:
+  Exclude:
+    - spec/**/*

--- a/.reek.yml
+++ b/.reek.yml
@@ -12,6 +12,7 @@ detectors:
     enabled: false
   TooManyStatements:
     exclude:
+      - Terminus::HTTP::Headers::Model#initialize
       - Terminus::Images::Greyscaler#convert
       - Terminus::Images::Screensaver#save
       - Terminus::Views::Parts::Device#battery_percentage

--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,7 @@ toc::[]
 
 * Allows you to run your own server.
 * Built atop {ruby_link} and {hanami_link}.
+* Provides automatic detection of your server's IP address.
 * Uses {htmx_link}.
 * Uses {puma_link}.
 * Uses {sqlite_link}.
@@ -44,7 +45,7 @@ The following is a high level overview you can use to compare/contrast when deci
 [options="header"]
 |===
 |                                   | Terminus | Hosted
-| Dashboard                         | 🟡       | 🟢
+| Dashboard                         | 🟢       | 🟢
 | Plugins                           | ⚪️       | 🟢
 | Playlists                         | 🟡       | 🟢
 | Playlist Previews                 | ⚪️       | 🟢
@@ -52,7 +53,7 @@ The following is a high level overview you can use to compare/contrast when deci
 | Devices                           | 🟢       | 🟢
 | Account                           | 🔴       | 🟢
 | JSON Data API                     | 🟢       | 🟢
-| Open Source Components            | 🟡       | 🟡
+| Open Source Components            | 🟢       | 🟡
 | Docker                            | 🟢       | 🔴
 |===
 
@@ -98,6 +99,14 @@ To view the app, use either of the following:
 * *Secure*: https://localhost:2443
 * *Insecure*: http://localhost:2300
 
+=== Configuration
+
+There are a few environment variables you can use to customize behavior:
+
+* `API_URI`: Needed for connecting your device to this server. Defaults to your wired IP address.
+* `DATABASE_URL`: Necessary to connect to your SQLite database. Defaults to the `db` folder but can be customized by changing the value in the `.env.development` or `.env.test` file created when you ran `bin/setup`.
+* `IMAGES_ROOT`: The root location for all generated images. Defaults to `public/assets/images`.
+
 === APIs
 
 The following APIs are supported. Each uses HTTPS which requires accepting your locally generated SSL certificate. If you don't want this behavior, you can switch to using HTTP (see above).
@@ -142,6 +151,17 @@ curl "https://localhost:2443/api/display/?base_64=true" \
      -H 'Accept: application/json' \
      -H 'Content-Type: application/json'
 ----
+
+Both the `ID` and `Access-Token` HTTP headers are required for all of these API calls but these _optional_ headers can be supplied as well which mimics what each device includes each request:
+
+* `HTTP_BATTERY_VOLTAGE`: Must a a float (usually 0.0 to 4.1).
+* `HTTP_FW_VERSION`: The firmware version (i.e. `1.2.3`).
+* `HTTP_HOST`: The host (usually the IP address).
+* `HTTP_REFRESH_RATE`: The refresh rate as saved on the device. Example: 100.
+* `HTTP_RSSI`: The signal strength (usually -100 to 100).
+* `HTTP_USER_AGENT`: The device name.
+* `HTTP_WIDTH`: The device width. Example: 800.
+* `HTTP_HEIGHT`: :The device height. Example: 480.
 ====
 
 .Response
@@ -236,7 +256,7 @@ Logs details and answers a HTTP 204 status with no content.
 
 ==== Images
 
-Used for generating new images by supplying HTML content for rendering, screenshotting, and greyscaling to render properly on your device.
+Used for generating new images by supplying HTML content for rendering, screenshotting, and grey scaling to render properly on your device.
 
 .Request
 [%collapsible]
@@ -426,11 +446,14 @@ Pure CSS is used since modern CSS is so powerful we don't need to reach for fram
 
 * *Colors*: Use to customize site colors.
 * *Defaults*: Use to customize HTML element defaults.
-* *Layout*: Use to customize the site layout.
 * *Settings*: Use to customize site settings.
+* *Layout*: Use to customize the site layout.
+* *Components*: Use to customize general site components.
 * *View Transitions*: Use to customize view transitions.
+* *Dashboard*: Use to customize the dashboard page.
+* *Devices*: Use to customize the devices page.
 
-For responsive resolutions, the following measuresments are used:
+For responsive resolutions, the following measurements are used:
 
 * *Extra Small*: 300px
 * *Small*: 500px
@@ -448,14 +471,6 @@ bin/rake
 ----
 
 == Deployment
-
-*Local*
-
-. Configure `APP_URL` within `+*.env+` file(s) to where your app is hosted (i.e. `https://192.168.x.x:2443`). 💡 Lack of trailing slash is important.
-. Retrieve your machine's local IP, ex 192.168.x.x (Mac: `ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'`).
-. Set `APP_URL` as the Custom Server via the [Firmware's](https://github.com/usetrmnl/firmware) WiFi Captive Portal
-
-*Hosted*
 
 More details to be provided soon.
 

--- a/app/actions/api/display/show.rb
+++ b/app/actions/api/display/show.rb
@@ -44,7 +44,7 @@ module Terminus
             encryption = :base_64 if (environment["HTTP_BASE64"] || parameters[:base_64]) == "true"
 
             fetcher.call Pathname(settings.images_root).join("generated"),
-                         images_uri: "#{settings.app_url}/assets/images",
+                         images_uri: "#{settings.api_uri}/assets/images",
                          encryption:
           end
 

--- a/app/actions/api/images/create.rb
+++ b/app/actions/api/images/create.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "initable"
+require "refinements/pathname"
 
 module Terminus
   module Actions

--- a/app/actions/dashboard/show.rb
+++ b/app/actions/dashboard/show.rb
@@ -1,11 +1,21 @@
 # frozen_string_literal: true
 
+require "initable"
+
 module Terminus
   module Actions
     module Dashboard
       # The show action.
       class Show < Terminus::Action
-        def handle(*) = super
+        include Deps[:settings, device_repository: "repositories.device"]
+        include Initable[ip_finder: proc { Terminus::IPFinder.new }]
+
+        def handle _request, response
+          response.render view,
+                          devices: device_repository.all,
+                          ip_addresses: ip_finder.all,
+                          api_uri: settings.api_uri
+        end
       end
     end
   end

--- a/app/assets/css/dashboard.css
+++ b/app/assets/css/dashboard.css
@@ -1,0 +1,18 @@
+.page-dashboard {
+  .widgets {
+    display: grid;
+    grid-template: 1fr / repeat(auto-fit, minmax(0, 1fr));
+    gap: 2rem;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .box {
+    background-color: var(--site-white);
+    border-radius: 0.5rem;
+  }
+
+  .label {
+    font-weight: 600;
+  }
+}

--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -4,4 +4,5 @@ import "../css/view_transitions.css";
 import "../css/defaults.css";
 import "../css/layout.css";
 import "../css/components.css";
+import "../css/dashboard.css";
 import "../css/devices.css";

--- a/app/models/api/responses/setup.rb
+++ b/app/models/api/responses/setup.rb
@@ -7,10 +7,10 @@ module Terminus
       module Responses
         # Models data for API setup responses.
         Setup = Struct.new :api_key, :friendly_id, :image_url, :message, :status do
-          def self.for device, environment: ENV
+          def self.for device
             new api_key: device.api_key,
                 friendly_id: device.friendly_id,
-                image_url: %(#{environment.fetch "APP_URL"}/images/setup/logo.bmp),
+                image_url: %(#{Hanami.app[:settings].api_uri}/images/setup/logo.bmp),
                 message: "Welcome to TRMNL BYOS",
                 status: 200
           end

--- a/app/templates/dashboard/show.html.erb
+++ b/app/templates/dashboard/show.html.erb
@@ -5,23 +5,55 @@
 
   <div class="widgets">
     <fieldset class="box">
-      <legend class="label">Devices</legend>
+      <legend class="label">
+        Devices
+        <button class="popover-trigger" popovertarget="popover-devices">ℹ️</button>
+      </legend>
 
       <ul class="list">
         <% devices.each do |device| %>
           <%= tag.li device.label %>
         <% end %>
       </ul>
+
+      <dialog id="popover-devices" class="popover-content" popover="auto">
+        <button class="close" popovertarget="popover-shortcuts" popovertargetaction="hide">
+          <span aria-hidden=true>❌</span>
+          <span class="screen_reader">Close</span>
+        </button>
+
+        <h3 class="label">Devices</h3>
+
+        <p>These are your currently registered devices.</p>
+      </dialog>
     </fieldset>
 
     <fieldset class="box">
-      <legend class="label">IP Addresses</legend>
+      <legend class="label">
+        IP Addresses
+        <button class="popover-trigger" popovertarget="popover-ip-addresses">ℹ️</button>
+      </legend>
 
       <ul class="list">
-        <% ip_addresses.each do |ip_address| %>
-          <%= tag.li ip_address %>
+        <% ip_addresses.each do |ip| %>
+          <%= tag.li ip.address_with_kind %>
         <% end %>
+
+        <li><%= api_uri %> (API)</li>
       </ul>
+
+      <dialog id="popover-ip-addresses" class="popover-content" popover="auto">
+        <button class="close" popovertarget="popover-shortcuts" popovertargetaction="hide">
+          <span aria-hidden=true>❌</span>
+          <span class="screen_reader">Close</span>
+        </button>
+
+        <h3 class="label">IP Addresses</h3>
+
+        <p>These are the Internet Protocol (IP) addresses of your local server. Use these to connect to your device. Use the API address to connect your device since you HTTPS isn't supported as of yet.</p>
+
+        <p>💡 Prefer wired over wireless since the former is likely not to change on you as much.</p>
+      </dialog>
     </fieldset>
   </div>
 </section>

--- a/app/templates/dashboard/show.html.erb
+++ b/app/templates/dashboard/show.html.erb
@@ -1,5 +1,27 @@
-<h1>Dashboard</h1>
+<section class="page-dashboard">
+  <header class="page-header">
+    <h1 class="label">Dashboard</h1>
+  </header>
 
-<p>Welcome to the Build Your Own Server (BYOS) application where you can customize and expand upon what's provided here to your hearts content. Anything is possible. Enjoy!</p>
+  <div class="widgets">
+    <fieldset class="box">
+      <legend class="label">Devices</legend>
 
-<p>To start, visit <a href="/devices">Devices</a> to configure, connect, and maintaining your own devices.</p>
+      <ul class="list">
+        <% devices.each do |device| %>
+          <%= tag.li device.label %>
+        <% end %>
+      </ul>
+    </fieldset>
+
+    <fieldset class="box">
+      <legend class="label">IP Addresses</legend>
+
+      <ul class="list">
+        <% ip_addresses.each do |ip_address| %>
+          <%= tag.li ip_address %>
+        <% end %>
+      </ul>
+    </fieldset>
+  </div>
+</section>

--- a/app/templates/devices/_device.html.erb
+++ b/app/templates/devices/_device.html.erb
@@ -3,29 +3,7 @@
 
   <h2 class="label"><%= device.label %></h2>
 
-  <div class="measurements">
-    <label class="measurement">
-      <%= tag.meter min: 0,
-                    low: 10,
-                    high: 90,
-                    optimum: 95,
-                    max: 100,
-                    value: device.battery_percentage,
-                    class: :battery %>
-      <%= format_number device.battery_percentage, precision: 0 %>% Battery
-    </label>
-
-    <label class="measurement">
-      <%= tag.meter min: 0,
-                    low: 10,
-                    high: 90,
-                    optimum: 95,
-                    max: 100,
-                    value: device.signal_percentage,
-                    class: :signal %>
-      <%= device.signal_percentage %>% Signal
-    </label>
-  </div>
+  <%= render "measurements", device: %>
 
   <div class="actions">
     <a href="/devices/info/<%= device.id %>"

--- a/app/templates/devices/_measurements.html.erb
+++ b/app/templates/devices/_measurements.html.erb
@@ -1,0 +1,23 @@
+<div class="measurements">
+  <label class="measurement">
+    <%= tag.meter min: 0,
+                  low: 25,
+                  high: 75,
+                  optimum: 95,
+                  max: 100,
+                  value: device.battery_percentage,
+                  class: :battery %>
+    <%= format_number device.battery_percentage, precision: 0 %>% Battery
+  </label>
+
+  <label class="measurement">
+    <%= tag.meter min: 0,
+                  low: 25,
+                  high: 75,
+                  optimum: 95,
+                  max: 100,
+                  value: device.signal_percentage,
+                  class: :signal %>
+    <%= device.signal_percentage %>% Signal
+  </label>
+</div>

--- a/app/templates/devices/info/show.html.erb
+++ b/app/templates/devices/info/show.html.erb
@@ -3,29 +3,7 @@
 
   <h2 class="label"><%= device.label %></h2>
 
-  <div class="measurements">
-    <label class="measurement">
-      <%= tag.meter min: 0,
-                    low: 10,
-                    high: 90,
-                    optimum: 95,
-                    max: 100,
-                    value: device.battery_percentage,
-                    class: :battery %>
-      <%= format_number device.battery_percentage, precision: 0 %>% Battery
-    </label>
-
-    <label class="measurement">
-      <%= tag.meter min: 0,
-                    low: 10,
-                    high: 90,
-                    optimum: 95,
-                    max: 100,
-                    value: device.signal_percentage,
-                    class: :signal %>
-      <%= device.signal_percentage %>% Signal
-    </label>
-  </div>
+  <%= render "devices/measurements", device: %>
 
   <div class="details">
     <h3 class="key">ID</h3>

--- a/app/views/dashboard/show.rb
+++ b/app/views/dashboard/show.rb
@@ -5,6 +5,9 @@ module Terminus
     module Dashboard
       # The show view.
       class Show < Terminus::View
+        expose :devices
+        expose :ip_addresses
+        expose :api_uri
       end
     end
   end

--- a/app/views/parts/ip_address.rb
+++ b/app/views/parts/ip_address.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "hanami/view"
+
+module Terminus
+  module Views
+    module Parts
+      # The dashboard presenter.
+      class IPAddress < Hanami::View::Part
+        def address = addr.ip_address
+
+        def address_with_kind = "#{address} (#{kind})"
+
+        def kind = name == "en0" ? :wireless : :wired
+      end
+    end
+  end
+end

--- a/bin/setup
+++ b/bin/setup
@@ -38,13 +38,7 @@ class Runner
     return kernel.puts ".env.development exists. Skipped." if path.exist?
 
     kernel.puts "Creawting .env.development..."
-
-    path.write <<~BODY
-      APP_HOST=0.0.0.0
-      APP_URL=https://localhost:2443
-      DATABASE_URL=sqlite://db/terminus.sqlite
-      IMAGES_ROOT=#{root}/public/assets/images
-    BODY
+    path.write "DATABASE_URL=sqlite://db/terminus.sqlite"
   end
 
   def setup_test_environment
@@ -53,13 +47,7 @@ class Runner
     return kernel.puts ".env.test exists. Skipped." if path.exist?
 
     kernel.puts "Creating .env.test..."
-
-    path.write <<~BODY
-      APP_HOST=localhost
-      APP_URL=https://localhost:2443
-      DATABASE_URL=sqlite://db/terminus.sqlite
-      IMAGES_ROOT=#{root}/tmp/rspec
-    BODY
+    path.write "DATABASE_URL=sqlite://db/terminus.sqlite"
   end
 
   def setup_development_procfile

--- a/config/app.rb
+++ b/config/app.rb
@@ -12,6 +12,8 @@ module Terminus
     Dry::Schema.load_extensions :monads
     Dry::Validation.load_extensions :monads
 
+    config.inflections { it.acronym "IP" }
+
     config.actions.content_security_policy.then do |csp|
       csp[:manifest_src] = "'self'"
       csp[:script_src] += " 'unsafe-eval' 'unsafe-inline' https://unpkg.com/"

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+require "terminus/ip_finder"
+
 module Terminus
   # The application base settings.
   class Settings < Hanami::Settings
-    setting :app_host, constructor: Types::Params::String
-    setting :app_url, constructor: Types::Params::String
-    setting :images_root, constructor: Types::Params::String
+    setting :api_uri,
+            constructor: Types::Params::String,
+            default: "http://#{IPFinder.new.wired}:2300"
+
+    setting :images_root,
+            constructor: Types::Params::String,
+            default: Hanami.app.root.join("public/assets/images").to_s
   end
 end

--- a/lib/terminus/http/headers/contract.rb
+++ b/lib/terminus/http/headers/contract.rb
@@ -5,15 +5,15 @@ module Terminus
     module Headers
       Contract = Dry::Schema.Params do
         required(:HTTP_ACCESS_TOKEN).filled :string
-        required(:HTTP_BATTERY_VOLTAGE).filled :float
-        required(:HTTP_FW_VERSION).filled Types::Version
-        required(:HTTP_HOST).filled :string
+        optional(:HTTP_BATTERY_VOLTAGE).filled :float
+        optional(:HTTP_FW_VERSION).filled Types::Version
+        optional(:HTTP_HOST).filled :string
         required(:HTTP_ID).filled :string
-        required(:HTTP_REFRESH_RATE).filled :integer
-        required(:HTTP_RSSI).filled :integer
-        required(:HTTP_USER_AGENT).filled :string
-        required(:HTTP_WIDTH).filled :integer
-        required(:HTTP_HEIGHT).filled :integer
+        optional(:HTTP_REFRESH_RATE).filled :integer
+        optional(:HTTP_RSSI).filled :integer
+        optional(:HTTP_USER_AGENT).filled :string
+        optional(:HTTP_WIDTH).filled :integer
+        optional(:HTTP_HEIGHT).filled :integer
       end
     end
   end

--- a/lib/terminus/http/headers/model.rb
+++ b/lib/terminus/http/headers/model.rb
@@ -17,8 +17,19 @@ module Terminus
       }.freeze
 
       # Models the HTTP headers for quick access of attributes.
-      Model = Data.define(*KEY_MAP.values) do
+      Model = Struct.new(*KEY_MAP.values) do
         def self.for(headers, key_map: KEY_MAP) = new(**headers.transform_keys(key_map))
+
+        def initialize(**)
+          super
+
+          self[:battery] ||= 0
+          self[:signal] ||= 0
+          self[:width] ||= 0
+          self[:height] ||= 0
+
+          freeze
+        end
 
         def device_attributes
           {battery:, firmware_version: firmware_version.to_s, signal:, width:, height:}

--- a/lib/terminus/ip_finder.rb
+++ b/lib/terminus/ip_finder.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "initable"
+require "socket"
+
+module Terminus
+  # Finds wired and wireless addresses.
+  class IPFinder
+    include Initable[socket: Socket]
+
+    def all pattern: /\A(en|wl|eth)/
+      socket.getifaddrs.select do
+        address = it.addr
+        it.name.match?(pattern) && address.ipv4? && !address.ipv4_loopback?
+      end
+    end
+
+    def wired pattern: /\A(en[1-9]|eth)/
+      all.find { |address| address.name.match? pattern }
+         .then { it.addr.ip_address if it }
+    end
+  end
+end

--- a/spec/app/actions/api/display/show_spec.rb
+++ b/spec/app/actions/api/display/show_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
       expect(payload).to include(
         filename: /.+\.bmp/,
         firmware_url: nil,
-        image_url: %r(https://localhost/assets/images/generated/.+\.bmp),
+        image_url: %r(http://.+/assets/images/generated/.+\.bmp),
         refresh_rate: 900,
         reset_firmware: false,
         special_function: "sleep",

--- a/spec/app/actions/api/setup/show_spec.rb
+++ b/spec/app/actions/api/setup/show_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Terminus::Actions::API::Setup::Show, :db do
         status: 200,
         api_key: "abc123",
         friendly_id: "ABC123",
-        image_url: %(#{ENV.fetch "APP_URL"}/images/setup/logo.bmp),
+        image_url: %(#{Hanami.app[:settings].api_uri}/images/setup/logo.bmp),
         message: "Welcome to TRMNL BYOS"
       )
     end

--- a/spec/app/models/api/responses/setup_spec.rb
+++ b/spec/app/models/api/responses/setup_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Terminus::Models::API::Responses::Setup, :db do
         described_class[
           api_key: "abc123",
           friendly_id: "ABC123",
-          image_url: %(#{ENV.fetch "APP_URL"}/images/setup/logo.bmp),
+          image_url: %(#{Hanami.app[:settings].api_uri}/images/setup/logo.bmp),
           message: "Welcome to TRMNL BYOS",
           status: 200
         ]

--- a/spec/app/views/parts/ip_address_spec.rb
+++ b/spec/app/views/parts/ip_address_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Views::Parts::IPAddress do
+  using Refinements::Pathname
+
+  subject(:part) { described_class.new value: address, rendering: view.new.rendering }
+
+  let :address do
+    instance_double(
+      Socket::Ifaddr,
+      name: "en0",
+      addr: instance_double(
+        Addrinfo,
+        ip_address: "192.168.1.111",
+        ipv4?: true,
+        ipv4_loopback?: false
+      )
+    )
+  end
+
+  let :view do
+    Class.new Hanami::View do
+      config.paths = [Hanami.app.root.join("app/templates")]
+      config.template = "n/a"
+    end
+  end
+
+  describe "#address" do
+    it "answers address" do
+      expect(part.address).to eq("192.168.1.111")
+    end
+  end
+
+  describe "#address_with_kind" do
+    it "answers address with kind in parenthesis" do
+      expect(part.address_with_kind).to eq("192.168.1.111 (wireless)")
+    end
+  end
+
+  describe "#kind" do
+    it "answers wired when name ends in zero" do
+      expect(part.kind).to eq(:wireless)
+    end
+
+    it "answers wireless when name ends in non-zero" do
+      allow(address).to receive(:name).and_return "en1"
+      expect(part.kind).to eq(:wired)
+    end
+  end
+end

--- a/spec/lib/terminus/http/headers/model_spec.rb
+++ b/spec/lib/terminus/http/headers/model_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe Terminus::HTTP::Headers::Model do
     end
   end
 
+  describe "#initialize" do
+    it "is frozen" do
+      expect(described_class.new.frozen?).to be(true)
+    end
+  end
+
   describe "#device_attributes" do
     it "answers device attributes" do
       expect(record.device_attributes).to eq(

--- a/spec/lib/terminus/ip_finder_spec.rb
+++ b/spec/lib/terminus/ip_finder_spec.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::IPFinder do
+  subject(:finder) { described_class.new socket: }
+
+  let(:socket) { class_double Socket }
+
+  before { allow(socket).to receive(:getifaddrs).and_return(addresses) }
+
+  describe "#all" do
+    let(:result) { finder.all.map { it.addr.ip_address } }
+
+    context %(with "en" network name) do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "en0",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers matching addresses" do
+        expect(result).to contain_exactly("192.168.1.111")
+      end
+    end
+
+    context %(with "wl" network name) do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "wlan0",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers matching addresses" do
+        expect(result).to contain_exactly("192.168.1.111")
+      end
+    end
+
+    context "with unknown network name" do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "bogus",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers empty array" do
+        expect(result).to eq([])
+      end
+    end
+
+    context "with custom pattern" do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "ps20",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers matching address" do
+        result = finder.all(pattern: /\Aps/).map { it.addr.ip_address }
+        expect(result).to contain_exactly("192.168.1.111")
+      end
+    end
+
+    context "when not IPV4" do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "en0",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: false,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers empty array" do
+        expect(result).to eq([])
+      end
+    end
+
+    context "when IPV4 loopback" do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "en0",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: true
+            )
+          )
+        ]
+      end
+
+      it "answers empty array" do
+        expect(result).to eq([])
+      end
+    end
+
+    context "when custom pattern" do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "ps20",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: true
+            )
+          )
+        ]
+      end
+
+      it "answers empty array" do
+        expect(result).to eq([])
+      end
+    end
+  end
+
+  describe "#wired" do
+    context %(with "en" name higher than zero) do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "en1",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers matching address" do
+        expect(finder.wired).to eq("192.168.1.111")
+      end
+    end
+
+    context %(with any "eth" name) do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "eth0",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers matching address" do
+        expect(finder.wired).to eq("192.168.1.111")
+      end
+    end
+
+    context %(with "en0" name) do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "en0",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers nil" do
+        expect(finder.wired).to be(nil)
+      end
+    end
+
+    context "with excluded name" do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "wlan0",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers nil" do
+        expect(finder.wired).to be(nil)
+      end
+    end
+
+    context "with custom pattern" do
+      let :addresses do
+        [
+          instance_double(
+            Socket::Ifaddr,
+            name: "wlan1",
+            addr: instance_double(
+              Addrinfo,
+              ip_address: "192.168.1.111",
+              ipv4?: true,
+              ipv4_loopback?: false
+            )
+          )
+        ]
+      end
+
+      it "answers matching address" do
+        expect(finder.wired(pattern: /\Awl/)).to eq("192.168.1.111")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview

This introduces an updated dashboard with high level information. This is simple, for now, but will be expanded upon further in the future. This also provides automatic IP detection of your wired ethernet address so you don't have to figure this out yourself or supply the IP address which reduces another setup step.

## Screenshots/Screencasts

![2025-03-19_19-25-31-Brave Browser](https://github.com/user-attachments/assets/64ccee94-5784-431b-88a7-d214be8b77cd)

## Details

- See commits for details.
- There are a few minor fixes in this work that are semi-related.