### PR TITLE
Added API client proxy

### DIFF
--- a/lib/terminus/api/client.rb
+++ b/lib/terminus/api/client.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+require "http"
+
+module Terminus
+  module API
+    # Provides a low level configurable and monadic API client.
+    class Client
+      include Initable[settings: proc { Terminus::API::Configuration.new }]
+      include Terminus::Dependencies[:http]
+      include Dry::Monads[:result]
+
+      def get path, access_token: nil, **parameters
+        call __method__, path, access_token: access_token, params: parameters
+      end
+
+      private
+
+      def call method, path, **options
+        headers = settings.headers.merge "Access-Token" => options.delete(:access_token)
+
+        http.headers(headers)
+            .public_send(method, "#{settings.api_uri}/#{path}", options)
+            .then { |response| response.status.success? ? Success(response) : Failure(response) }
+      end
+    end
+  end
+end

--- a/lib/terminus/api/configuration.rb
+++ b/lib/terminus/api/configuration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Terminus
+  module API
+    # Provides API client configuration with safe defaults.
+    Configuration = Data.define :api_uri, :headers do
+      def initialize api_uri: "https://trmnl.app/api", headers: {accept: "application/json"}
+        super
+      end
+    end
+  end
+end

--- a/lib/terminus/dependencies.rb
+++ b/lib/terminus/dependencies.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "infusible"
+
+module Terminus
+  # Defines application dependencies for automatic injection.
+  Dependencies = Infusible[LibContainer]
+end

--- a/lib/terminus/endpoints/container.rb
+++ b/lib/terminus/endpoints/container.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "containable"
+
+module Terminus
+  module Endpoints
+    # Registers endpoint dependencies.
+    module Container
+      extend Containable
+
+      register(:client) { API::Client.new }
+
+      namespace :contracts do
+        register :current_screen, CurrentScreen::Contract
+        register :display, Display::Contract
+      end
+
+      namespace :responses do
+        register :current_screen, CurrentScreen::Response
+        register :display, Display::Response
+      end
+    end
+  end
+end

--- a/lib/terminus/endpoints/current_screen/contract.rb
+++ b/lib/terminus/endpoints/current_screen/contract.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "dry/schema"
+
+module Terminus
+  module Endpoints
+    module CurrentScreen
+      # Defines API response contract.
+      Contract = Dry::Schema.JSON do
+        required(:refresh_rate).filled :integer
+        required(:image_url).filled :string
+        required(:filename).filled :string
+      end
+    end
+  end
+end

--- a/lib/terminus/endpoints/current_screen/requester.rb
+++ b/lib/terminus/endpoints/current_screen/requester.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "pipeable"
+
+module Terminus
+  module Endpoints
+    module CurrentScreen
+      # Acquires API repsonse.
+      class Requester
+        include Dependencies[
+          :client,
+          contract: "contracts.current_screen",
+          response: "responses.current_screen"
+        ]
+
+        include Pipeable
+
+        def call access_token:
+          pipe client.get("current_screen", access_token:),
+               try(:parse, catch: JSON::ParserError),
+               validate(contract, as: :to_h),
+               to(response, :for)
+        end
+      end
+    end
+  end
+end

--- a/lib/terminus/endpoints/current_screen/response.rb
+++ b/lib/terminus/endpoints/current_screen/response.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Endpoints
+    module CurrentScreen
+      # Models API response.
+      Response = Data.define :refresh_rate, :image_url, :filename do
+        def self.for(attributes) = new(**attributes)
+      end
+    end
+  end
+end

--- a/lib/terminus/endpoints/dependencies.rb
+++ b/lib/terminus/endpoints/dependencies.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "infusible"
+
+module Terminus
+  # Defines endpoint dependencies for automatic injection.
+  module Endpoints
+    Dependencies = Infusible[Container]
+  end
+end

--- a/lib/terminus/endpoints/display/contract.rb
+++ b/lib/terminus/endpoints/display/contract.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "dry/schema"
+
+module Terminus
+  module Endpoints
+    module Display
+      # Defines API response contract.
+      Contract = Dry::Schema.JSON do
+        required(:filename).filled :string
+        required(:firmware_url).filled :string
+        required(:image_url).filled :string
+        required(:refresh_rate).filled :integer
+        required(:reset_firmware).filled :bool
+        required(:special_function).filled :string
+        required(:update_firmware).filled :bool
+      end
+    end
+  end
+end

--- a/lib/terminus/endpoints/display/requester.rb
+++ b/lib/terminus/endpoints/display/requester.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "pipeable"
+
+module Terminus
+  module Endpoints
+    module Display
+      # Gets API repsonse.
+      class Requester
+        include Dependencies[:client, contract: "contracts.display", response: "responses.display"]
+        include Pipeable
+
+        def call access_token:
+          pipe client.get("display", access_token:),
+               try(:parse, catch: JSON::ParserError),
+               validate(contract, as: :to_h),
+               to(response, :for)
+        end
+      end
+    end
+  end
+end

--- a/lib/terminus/endpoints/display/response.rb
+++ b/lib/terminus/endpoints/display/response.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Endpoints
+    module Display
+      # Models data for API display responses.
+      Response = Struct.new(
+        :filename,
+        :firmware_url,
+        :image_url,
+        :image_url_timeout,
+        :refresh_rate,
+        :reset_firmware,
+        :special_function,
+        :update_firmware
+      ) do
+        def self.for(attributes) = new(**attributes)
+
+        def initialize(**)
+          super
+          apply_defaults
+          freeze
+        end
+
+        def to_json(*) = to_h.to_json(*)
+
+        private
+
+        def apply_defaults
+          self[:image_url_timeout] ||= 0
+          self[:refresh_rate] ||= 300
+          self[:reset_firmware] ||= false
+          self[:update_firmware] ||= false
+          self[:special_function] ||= "sleep"
+        end
+      end
+    end
+  end
+end

--- a/lib/terminus/lib_container.rb
+++ b/lib/terminus/lib_container.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "cogger"
+require "containable"
+require "http"
+
+module Terminus
+  # Registers application dependencies.
+  module LibContainer
+    extend Containable
+
+    register :http do
+      ::HTTP.default_options = ::HTTP::Options.new features: {logging: {logger: self[:logger]}}
+      ::HTTP
+    end
+
+    register(:logger) { Cogger.new id: :terminus, formatter: :json }
+  end
+end

--- a/spec/lib/terminus/api/client_spec.rb
+++ b/spec/lib/terminus/api/client_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::API::Client do
+  using Refinements::Hash
+
+  subject(:client) { described_class.new settings: Terminus::API::Configuration.new, http: }
+
+  describe "#get" do
+    include_context "with fake HTTP current screen"
+
+    it "answers success response" do
+      response = client.get "current_screen", access_token: "secret"
+      payload = response.fmap(&:parse).bind(&:symbolize_keys!)
+
+      expect(payload).to eq(
+        status: 200,
+        refresh_rate: 3200,
+        image_url: "https://test.io/images/test.bmp",
+        filename: "test.bmp",
+        rendered_at: nil
+      )
+    end
+
+    context "with failure" do
+      let :http do
+        HTTP::Fake::Client.new do
+          get "/api/current_screen" do
+            headers["Content-Type"] = "application/json"
+            status 404
+
+            <<~JSON
+              {
+                "message": "Danger!"
+              }
+            JSON
+          end
+        end
+      end
+
+      it "answers failure response" do
+        response = client.get "current_screen"
+        payload = response.alt_map { |result| result.parse.symbolize_keys! }
+
+        expect(payload).to be_failure(message: "Danger!")
+      end
+    end
+  end
+end

--- a/spec/lib/terminus/api/configuration_spec.rb
+++ b/spec/lib/terminus/api/configuration_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::API::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe "#initialize" do
+    it "answers default attributes" do
+      expect(configuration).to eq(
+        described_class[api_uri: "https://trmnl.app/api", headers: {accept: "application/json"}]
+      )
+    end
+
+    it "answers custom attributes" do
+      configuration = described_class[
+        api_uri: "https://test.io/api",
+        headers: {accept: "text/plain"}
+      ]
+
+      expect(configuration).to eq(
+        described_class[api_uri: "https://test.io/api", headers: {accept: "text/plain"}]
+      )
+    end
+  end
+end

--- a/spec/lib/terminus/endpoints/current_screen/requester_spec.rb
+++ b/spec/lib/terminus/endpoints/current_screen/requester_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Endpoints::CurrentScreen::Requester do
+  subject(:requester) { described_class.new client: }
+
+  let(:client) { Terminus::API::Client.new http: }
+
+  describe "#call" do
+    include_context "with fake HTTP current screen"
+
+    it "answers success" do
+      response = requester.call access_token: "secret"
+
+      expect(response).to be_success(
+        Terminus::Endpoints::CurrentScreen::Response[
+          refresh_rate: 3200,
+          image_url: "https://test.io/images/test.bmp",
+          filename: "test.bmp"
+        ]
+      )
+    end
+
+    it "answers failure when attributes are missing" do
+      response = described_class.new.call access_token: "secret"
+      expect(response).to be_failure(Terminus::Endpoints::CurrentScreen::Contract.call({}))
+    end
+  end
+end

--- a/spec/lib/terminus/endpoints/current_screen/response_spec.rb
+++ b/spec/lib/terminus/endpoints/current_screen/response_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Endpoints::CurrentScreen::Response do
+  describe ".for" do
+    it "answers record for attributes" do
+      attributes = {refresh_rate: 1, image_url: "https://test.io", filename: "test"}
+
+      expect(described_class.for(attributes)).to eq(described_class[**attributes])
+    end
+  end
+end

--- a/spec/lib/terminus/endpoints/display/requester_spec.rb
+++ b/spec/lib/terminus/endpoints/display/requester_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Endpoints::Display::Requester do
+  subject(:requester) { described_class.new client: }
+
+  let(:client) { Terminus::API::Client.new http: }
+
+  describe "#call" do
+    include_context "with fake HTTP display"
+
+    it "answers success" do
+      response = requester.call access_token: "secret"
+      expect(response).to be_success(
+        Terminus::Endpoints::Display::Response[
+          filename: "test.bmp",
+          firmware_url: "https://test.io/FW1.4.8.bin",
+          image_url: "https://test.io/images/test.bmp",
+          refresh_rate: 3200,
+          reset_firmware: false,
+          special_function: "restart_playlist",
+          update_firmware: true
+        ]
+      )
+    end
+
+    it "answers failure when attributes are missing" do
+      response = described_class.new.call access_token: "secret"
+
+      expect(response).to be_failure(
+        Terminus::Endpoints::Display::Contract.call({reset_firmware: true})
+      )
+    end
+  end
+end

--- a/spec/lib/terminus/endpoints/display/response_spec.rb
+++ b/spec/lib/terminus/endpoints/display/response_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Endpoints::Display::Response do
+  subject(:model) { described_class.new }
+
+  describe ".for" do
+    let :attributes do
+      {
+        filename: "test.bmp",
+        firmware_url: "https://test.io/FW1.4.8.bin",
+        image_url: "https://test.io/images/test.bmp",
+        refresh_rate: 3200,
+        reset_firmware: false,
+        special_function: "restart_playlist",
+        update_firmware: true
+      }
+    end
+
+    it "answers record for attributes" do
+      expect(described_class.for(attributes)).to eq(described_class[**attributes])
+    end
+  end
+
+  describe "#initialize" do
+    it "answers default attributes" do
+      expect(model.to_h).to eq(
+        filename: nil,
+        firmware_url: nil,
+        image_url: nil,
+        image_url_timeout: 0,
+        refresh_rate: 300,
+        reset_firmware: false,
+        special_function: "sleep",
+        update_firmware: false
+      )
+    end
+
+    it "is frozen" do
+      expect(model.frozen?).to be(true)
+    end
+  end
+
+  describe "#to_json" do
+    it "answers JSON" do
+      payload = JSON model.to_json, symbolize_names: true
+
+      expect(payload).to eq(
+        filename: nil,
+        firmware_url: nil,
+        image_url: nil,
+        image_url_timeout: 0,
+        refresh_rate: 300,
+        reset_firmware: false,
+        special_function: "sleep",
+        update_firmware: false
+      )
+    end
+  end
+end

--- a/spec/support/shared_contexts/fake_http_current_screen.rb
+++ b/spec/support/shared_contexts/fake_http_current_screen.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with fake HTTP current screen" do
+  let :http do
+    HTTP::Fake::Client.new do
+      get "/api/current_screen" do
+        headers["Content-Type"] = "application/json"
+        status 200
+
+        <<~JSON
+          {
+            "status": 200,
+            "refresh_rate": 3200,
+            "image_url": "https://test.io/images/test.bmp",
+            "filename": "test.bmp",
+            "rendered_at": null
+          }
+        JSON
+      end
+    end
+  end
+end

--- a/spec/support/shared_contexts/fake_http_display.rb
+++ b/spec/support/shared_contexts/fake_http_display.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with fake HTTP display" do
+  let :http do
+    HTTP::Fake::Client.new do
+      get "/api/display" do
+        headers["Content-Type"] = "application/json"
+        status 200
+
+        <<~JSON
+          {
+            "filename": "test.bmp",
+            "firmware_url": "https://test.io/FW1.4.8.bin",
+            "image_url": "https://test.io/images/test.bmp",
+            "refresh_rate": 3200,
+            "reset_firmware": false,
+            "special_function": "restart_playlist",
+            "status": 0,
+            "update_firmware": true
+          }
+        JSON
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview

This provides the foundation for proxy'ing API requests to the Core server on behalf of a device. This also implements the seeds of a potential API client which we could extract into a seperate gem which is why this is implemented in the `lib` folder for easy extraction.

This adds support for the following API endpoints:

- `/api/current_screen`
- `/api/display`

With this in place, I'll be able to teach devices how to proxy to Core in case using local image generation isn't desired. This also opens up the capability of being able to access the entire Core ecoystem in terms of playlists, plugins, recipes, etc.

## Details

- See commits for details.