### PR TITLE
Added device proxy of remote images

### DIFF
--- a/app/aspects/screens/downloader.rb
+++ b/app/aspects/screens/downloader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "refinements/pathname"
+
 module Terminus
   module Aspects
     module Screens

--- a/app/aspects/screens/downloader.rb
+++ b/app/aspects/screens/downloader.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Aspects
+    module Screens
+      # A basic file downloader for screen images.
+      class Downloader
+        include Deps[:settings]
+        include Dependencies[client: :http]
+        include Initable[offset: 10] # Seconds.
+        include Dry::Monads[:result]
+
+        using Refinements::Pathname
+
+        def call uri, file_name
+          at = oldest_at
+
+          get(uri).fmap do |content|
+            Pathname(settings.generated_root).join(file_name).write(content).touch at
+          end
+        end
+
+        def oldest_at
+          oldest_file = Pathname(settings.generated_root).files.min_by(&:mtime)
+
+          return Time.now unless oldest_file
+
+          oldest_file.mtime - offset
+        end
+
+        def get uri
+          client.get(uri)
+                .then do |response|
+                  response.status.success? ? Success(response) : Failure(response)
+                end
+        end
+      end
+    end
+  end
+end

--- a/app/aspects/screens/poller.rb
+++ b/app/aspects/screens/poller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Aspects
+    module Screens
+      # Polls the Core Display API on a scheduled interval for new images to display locally.
+      class Poller
+        include Deps[repository: "repositories.device"]
+
+        # :nocov:
+        include Initable[
+          endpoint: proc { Terminus::Endpoints::Display::Requester.new },
+          downloader: proc { Terminus::Aspects::Screens::Downloader.new },
+          kernel: Kernel,
+          seconds: 300
+        ]
+
+        def call
+          kernel.loop do
+            process_devices
+            kernel.sleep seconds
+          end
+        end
+
+        private
+
+        def process_devices
+          repository.all.select(&:proxy).each { |device| process device }
+        end
+
+        def process device
+          endpoint.call(access_token: device.api_key)
+                  .bind do |response|
+                    downloader.call response.image_url, response.filename
+                  end
+        end
+      end
+    end
+  end
+end

--- a/bin/screen_poller
+++ b/bin/screen_poller
@@ -1,0 +1,10 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+Bundler.require :tools
+
+require "hanami/prepare"
+
+poller = Hanami.app["aspects.screens.poller"]
+poller.call

--- a/spec/app/aspects/screens/downloader_spec.rb
+++ b/spec/app/aspects/screens/downloader_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Aspects::Screens::Downloader do
+  using Refinements::Pathname
+
+  subject(:downloader) { described_class.new client: }
+
+  include_context "with temporary directory"
+
+  let(:client) { HTTP }
+  let(:settings) { Hanami.app[:settings] }
+
+  describe "#call" do
+    before { allow(settings).to receive(:generated_root).and_return temp_dir }
+
+    it "downloads file" do
+      downloader.call "https://usetrmnl.com/assets/mashups.png", "test.png"
+      expect(temp_dir.join("test.png").exist?).to be(true)
+    end
+
+    it "marks downloaded file older than oldest file" do
+      temp_dir.join("test.txt").write("test").touch Time.new(2000, 1, 1, 0, 0, 0)
+      downloader.call "https://usetrmnl.com/assets/mashups.png", "test.png"
+
+      expect(temp_dir.join("test.png").mtime.year).to eq(1999)
+    end
+
+    it "answers output path" do
+      result = downloader.call "https://usetrmnl.com/assets/mashups.png", "test.png"
+
+      expect(result).to be_success(temp_dir.join("test.png"))
+    end
+
+    it "answers failure when image can't be downloaded" do
+      code = downloader.call("https://test.io/bogus.png", "bogus.png").alt_map { it.status.code }
+      expect(code).to be_failure(404)
+    end
+  end
+end

--- a/spec/app/aspects/screens/poller_spec.rb
+++ b/spec/app/aspects/screens/poller_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Aspects::Screens::Poller, :db do
+  subject(:poller) { described_class.new repository:, endpoint:, downloader:, kernel: }
+
+  let(:repository) { instance_double Terminus::Repositories::Device, all: devices }
+  let(:devices) { [Factory[:device, api_key: "abc123", proxy: true]] }
+  let(:kernel) { class_double Kernel, sleep: nil }
+
+  let :endpoint do
+    instance_spy Terminus::Endpoints::Display::Requester,
+                 call: Success(
+                   Terminus::Endpoints::Display::Response[
+                     image_url: "https://test.io/test.bmp",
+                     filename: "test.bmp"
+                   ]
+                 )
+  end
+
+  let(:downloader) { instance_spy Terminus::Aspects::Screens::Downloader }
+
+  describe "#call" do
+    before { allow(kernel).to receive(:loop).and_yield }
+
+    it "requests image for device API key" do
+      poller.call
+      expect(endpoint).to have_received(:call).with access_token: "abc123"
+    end
+
+    it "downloads image" do
+      poller.call
+      expect(downloader).to have_received(:call).with "https://test.io/test.bmp", "test.bmp"
+    end
+
+    context "with no devices" do
+      let(:devices) { [] }
+
+      it "doesn't download image" do
+        poller.call
+        expect(downloader).not_to have_received(:call)
+      end
+    end
+
+    context "with no proxied devices" do
+      let(:devices) { [Factory[:device]] }
+
+      it "doesn't download image" do
+        poller.call
+        expect(downloader).not_to have_received(:call)
+      end
+    end
+
+    context "with remote image failure" do
+      let :endpoint do
+        instance_spy Terminus::Endpoints::Display::Requester, call: Failure("Danger!")
+      end
+
+      it "doesn't download image" do
+        poller.call
+        expect(downloader).not_to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/lib/terminus/endpoints/current_screen/requester_spec.rb
+++ b/spec/lib/terminus/endpoints/current_screen/requester_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Terminus::Endpoints::CurrentScreen::Requester do
 
     it "answers failure when attributes are missing" do
       response = described_class.new.call access_token: "secret"
-      expect(response).to be_failure(Terminus::Endpoints::CurrentScreen::Contract.call({}))
+      expect(response).to match(Failure(be_a(HTTP::Response)))
     end
   end
 end


### PR DESCRIPTION
## Overview

The following allows you to enable proxying for your device so that images will come from the Core server instead of locally. This is a great first start but more work is required because, up to this point, all files are being managed (and rotated as a lightweight playlist) based on file modification time. This isn't ideal.

That said, and for now, you can toggle your device to proxy via the UI and then run `bin/screen_poller` as part of your `Procfile` as a background process that checks for updates every 5 minutes.

I will smooth this out soon but, for now, allows people to play with for a bit and leverage the fully capabilities of the Core server if you don't want to render local images (or mix-n-match as you see fit).

## Details

- See commits for details.