### PR TITLE
Added device builder

### DIFF
--- a/app/actions/api/setup/show.rb
+++ b/app/actions/api/setup/show.rb
@@ -9,8 +9,8 @@ module Terminus
       module Setup
         # The show action.
         class Show < Terminus::Action
-          include Deps[repository: "repositories.device"]
-          include Initable[randomizer: SecureRandom, model: Aspects::API::Responses::Setup]
+          include Deps[repository: "repositories.device", device_builder: "aspects.devices.builder"]
+          include Initable[model: Aspects::API::Responses::Setup]
 
           format :json
 
@@ -24,17 +24,8 @@ module Terminus
           private
 
           def create_device mac_address, firmware_version
-            repository.create label: "TRMNL",
-                              friendly_id: generate_friendly_id,
-                              mac_address:,
-                              api_key: generate_api_key,
-                              firmware_version:,
-                              setup_at: Time.now
+            repository.create device_builder.call.merge(mac_address:, firmware_version:)
           end
-
-          def generate_friendly_id = randomizer.hex(3).upcase
-
-          def generate_api_key = randomizer.alphanumeric 20
         end
       end
     end

--- a/app/aspects/devices/builder.rb
+++ b/app/aspects/devices/builder.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Terminus
+  module Aspects
+    module Devices
+      # Builds default attributes for new devices.
+      class Builder
+        include Initable[randomizer: SecureRandom, time: Time]
+
+        def call
+          {
+            label: "TRMNL",
+            friendly_id: randomizer.hex(3).upcase,
+            api_key: randomizer.alphanumeric(20),
+            refresh_rate: 900,
+            image_timeout: 0,
+            setup_at: time.now
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/structs/device.rb
+++ b/app/structs/device.rb
@@ -4,7 +4,7 @@ module Terminus
   module Structs
     # The device struct.
     class Device < DB::Struct
-      def as_api_display = {image_url_timeout: image_timeout, refresh_rate: refresh_rate}
+      def as_api_display = {image_url_timeout: image_timeout, refresh_rate:}
     end
   end
 end

--- a/app/views/devices/new.rb
+++ b/app/views/devices/new.rb
@@ -5,8 +5,10 @@ module Terminus
     module Devices
       # The new view.
       class New < Terminus::View
+        include Deps[builder: "aspects.devices.builder"]
+
         expose :device
-        expose :fields, default: Dry::Core::EMPTY_HASH
+        expose(:fields) { builder.call }
         expose :errors, default: Dry::Core::EMPTY_HASH
       end
     end

--- a/spec/app/actions/devices/new_spec.rb
+++ b/spec/app/actions/devices/new_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Terminus::Actions::Devices::New do
       expect(response.status).to eq(200)
     end
 
+    it "renders defaults" do
+      device = {mac_address: "aa:bb:cc:11:22:33"}
+      response = Rack::MockRequest.new(action).post "", params: {device:}
+
+      expect(response.body).to include(%(name="device[label]" value="TRMNL"))
+    end
+
     it "renders htmx response" do
-      device = {
-        label: "Test",
-        friendly_id: "ABC123",
-        mac_address: "aa:bb:cc:11:22:33",
-        api_key: "abc",
-        refresh_rate: 100,
-        image_timeout: 100
-      }
+      device = {mac_address: "aa:bb:cc:11:22:33"}
 
       response = Rack::MockRequest.new(action)
                                   .post "", "HTTP_HX_REQUEST" => "true", params: {device:}

--- a/spec/app/aspects/devices/builder_spec.rb
+++ b/spec/app/aspects/devices/builder_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Aspects::Devices::Builder do
+  subject(:builder) { described_class.new randomizer:, time: }
+
+  let :randomizer do
+    class_double SecureRandom, hex: "abc123", alphanumeric: "Ov2tWq4XoYCH2xPfiZqc"
+  end
+
+  let(:time) { class_double Time, now: at }
+  let(:at) { Time.new 2025, 1, 2, 3, 4, 5 }
+
+  describe "#call" do
+    it "answers defaults" do
+      expect(builder.call).to eq(
+        label: "TRMNL",
+        friendly_id: "ABC123",
+        api_key: "Ov2tWq4XoYCH2xPfiZqc",
+        refresh_rate: 900,
+        image_timeout: 0,
+        setup_at: at
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Overview

Necessary to make device setup consistent both when setting up a new devcie via the UI and when auto-provisioned via the Setup API. Both use safe defaults now.

## Screenshots/Screencasts

![2025-04-03_11-53-28-iPhone Mirroring](https://github.com/user-attachments/assets/96c0354e-b5a7-4a13-a921-a75402a8f553)

## Details

- See commits for details.