### PR TITLE
Added form popovers, secret protection, and poller setup

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma --config ./config/puma.rb
 assets: bundle exec hanami assets compile
+poller: bin/screen_poller

--- a/README.adoc
+++ b/README.adoc
@@ -46,13 +46,14 @@ The following is a high level overview you can use to compare/contrast when deci
 |===
 |                                   | Terminus | Hosted
 | Dashboard                         | 🟢       | 🟢
-| Plugins                           | ⚪️       | 🟢
-| Playlists                         | 🟡       | 🟢
-| Playlist Previews                 | ⚪️       | 🟢
-| Recipes                           | 🔴       | 🟢
+| Auto-Provisioning                 | 🟢       | 🟢
 | Devices                           | 🟢       | 🟢
-| Account                           | 🔴       | 🟢
 | JSON Data API                     | 🟢       | 🟢
+| Image Previews                    | ⚪️       | 🟢
+| Playlists                         | 🟡       | 🟢
+| Plugins                           | ⚪️       | 🟢
+| Recipes                           | 🔴       | 🟢
+| Account                           | 🔴       | 🟢
 | Open Source Components            | 🟢       | 🟡
 | Docker                            | 🟢       | 🔴
 |===
@@ -107,6 +108,17 @@ There are a few environment variables you can use to customize behavior:
 * `API_URI`: Needed for connecting your device to this server. Defaults to your wired IP address.
 * `DATABASE_URL`: Necessary to connect to your {postgres_link} database. Can be customized by changing the value in the `.env.development` or `.env.test` file created when you ran `bin/setup`.
 * `SCREENS_ROOT`: The root location for all device screens (images). Defaults to `public/assets/screens`.
+
+=== Device Provisioning
+
+There are a couple of ways you can provision a device with this server.
+
+The first is automatic which happens immediately after you have successfully used the WiFi captive portal on your mobile phone to connect your TRMNL device to your local network where this server is running. You can also delete your device, via the UI, and it'll be reconfigured for you automatically when the device next makes a xref:_display[Display API] request.
+
+
+The second way is to manually add your device via the UI. At a minimum, you only need to know your device's MAC Address when entering your device information within the UI.
+
+That's it!
 
 === APIs
 
@@ -502,7 +514,19 @@ bin/rake
 
 == Deployment
 
-More details to be provided soon.
+{docker_link} is supported both for production and development purposes. Each is explained below.
+
+=== Development
+
+To develop with Docker, there is a `.devcontainer` folder that should provide the initial foundation from which to customize further for your needs.
+
+=== Production
+
+To build an image for production purpose, use the `Dockerfile` and `bin/docker` scripts. Here's how each works:
+
+* `bin/docker/build`: This will build a production Docker image based on latest changes to this project.
+* `bin/docker/console`: This will immediately give you a console for which to explore you Docker image from the command line.
+* `bin/docker/entrypoint`: This is used by the `Dockerfile` when building your Docker image.
 
 == Credits
 

--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -123,6 +123,15 @@
   }
 }
 
+.site-secret {
+  filter: blur(4px);
+  transition: filter 0.3s ease;
+
+  &:hover, &:focus, &:active {
+    filter: blur(0);
+  }
+}
+
 .site-table {
   .text-left {
     text-align: left;
@@ -217,17 +226,19 @@
   }
 
   .form-field {
+    align-items: center;
     display: flex;
     flex-direction: column;
     margin: 0;
+    gap: 1rem;
   }
 
   .key {
     align-items: center;
     display: flex;
-    flex-direction: column;
     font-weight: 600;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
   .value {
@@ -239,6 +250,7 @@
   .form-actions {
     display: flex;
     align-items: center;
+    gap: 1rem;
   }
 
   .accept, .decline {

--- a/app/templates/dashboard/show.html.erb
+++ b/app/templates/dashboard/show.html.erb
@@ -40,10 +40,10 @@
 
       <ul class="list">
         <% ip_addresses.each do |ip| %>
-          <%= tag.li ip.address_with_kind %>
+          <%= tag.li ip.address_with_kind, class: "site-secret" %>
         <% end %>
 
-        <li><%= api_uri %> (API)</li>
+        <li class="site-secret"><%= api_uri %> (API)</li>
       </ul>
 
       <dialog id="popover-ip-addresses" class="popover-content" popover="auto">

--- a/app/templates/devices/_delete_link.html.erb
+++ b/app/templates/devices/_delete_link.html.erb
@@ -1,7 +1,0 @@
-<a href="/devices"
-   class="link-cancel"
-   hx-delete="/devices/<%= device.id %>"
-   hx-target="closest .device"
-   hx-swap="outerHTML">
-  Delete
-</a>

--- a/app/templates/devices/_device.html.erb
+++ b/app/templates/devices/_device.html.erb
@@ -9,6 +9,14 @@
     <%= link_to "View", "/devices/#{device.id}" %>
     <%= link_to "Logs", "/devices/#{device.id}/logs" %>
     <%= render "edit_link", device: %>
-    <%= render "delete_link", device: %>
+
+    <a href="/devices"
+       class="link-cancel"
+       hx-delete="/devices/<%= device.id %>"
+       hx-confirm="Are you sure you want to delete this device?"
+       hx-target="closest .device"
+       hx-swap="outerHTML">
+      Delete
+    </a>
   </div>
 </li>

--- a/app/templates/devices/_field_popover_content.html.erb
+++ b/app/templates/devices/_field_popover_content.html.erb
@@ -1,0 +1,12 @@
+<dialog id="popover-<%= name %>" class="popover-content" popover="auto">
+  <button type="button"
+          class="close"
+          popovertarget="popover-<%= name %>"
+          popovertargetaction="hide">
+          <span aria-hidden=true>❌</span>
+          <span class="screen_reader">Close</span>
+  </button>
+
+  <h3 class="label"><%= label %></h3>
+  <p><%= body %></p>
+</dialog>

--- a/app/templates/devices/_field_popover_trigger.html.erb
+++ b/app/templates/devices/_field_popover_trigger.html.erb
@@ -1,0 +1,1 @@
+<button type="button" class="popover-trigger" popovertarget="popover-<%= name %>">ℹ️</button>

--- a/app/templates/devices/_fields.html.erb
+++ b/app/templates/devices/_fields.html.erb
@@ -1,72 +1,117 @@
 <fieldset role="group" class="group">
   <%= scope(:form_field, key: :label, errors:).render do %>
-    <label class="key">
-      Label
-      <%= tag.input name: "device[label]",
-                    value: field_for(:label, fields, device),
-                    class: :value,
-                    autocomplete: :label %>
-    </label>
+    <label class="key" for="device[label]">Label</label>
+
+    <%= tag.input name: "device[label]",
+                  value: field_for(:label, fields, device),
+                  class: :value,
+                  autocomplete: :label %>
   <% end %>
 
   <%= scope(:form_field, key: :friendly_id, errors:).render do %>
-    <label class="key">
+    <label class="key" for="device[friendly_id]">
       Friendly ID
-      <%= tag.input name: "device[friendly_id]",
-                    value: field_for(:friendly_id, fields, device),
-                    class: :value,
-                    autocomplete: :friendly_id %>
+      <%= render "field_popover_trigger", name: "friendly_id" %>
     </label>
+
+    <%= tag.input name: "device[friendly_id]",
+                  value: field_for(:friendly_id, fields, device),
+                  class: :value,
+                  autocomplete: :friendly_id %>
   <% end %>
+
+  <%= render "field_popover_content",
+             name: "friendly_id",
+             label: "Friendly ID",
+             body: "Provides a way to uniquely identify your device." %>
 
   <%= scope(:form_field, key: :mac_address, errors:).render do %>
-    <label class="key">
+    <label class="key" for="device[mac_address]">
       MAC Address
-      <%= tag.input name: "device[mac_address]",
-                    value: field_for(:mac_address, fields, device),
-                    class: :value,
-                    autocomplete: :mac_address %>
+      <%= render "field_popover_trigger", name: "mac_address" %>
     </label>
+
+    <%= tag.input name: "device[mac_address]",
+                  type: :password,
+                  value: field_for(:mac_address, fields, device),
+                  class: :value,
+                  autocomplete: :mac_address %>
   <% end %>
+
+  <%= render "field_popover_content",
+             name: "mac_address",
+             label: "MAC Address",
+             body: "Uniquely identifies your device when communicating over the network." %>
 
   <%= scope(:form_field, key: :proxy, errors:).render do %>
-    <label class="key">
+    <label class="key" for="device[proxy]">
       Proxy
-      <%= tag.input name: "device[proxy]",
-                    type: :checkbox,
-                    checked: field_for(:proxy, fields, device),
-                    switch: true,
-                    class: :value %>
+      <%= render "field_popover_trigger", name: "proxy" %>
     </label>
+
+    <%= tag.input name: "device[proxy]",
+                  type: :checkbox,
+                  checked: field_for(:proxy, fields, device),
+                  switch: true,
+                  class: :value %>
   <% end %>
+
+  <%= render "field_popover_content",
+             name: "proxy",
+             label: "Proxy",
+             body: "Allows you to display remote images generated via your TRMNL account when enabled. This includes locally generated images but the remote images will take precedence. Your MAC address and API key must be identical both locally and remotely for this to work." %>
 
   <%= scope(:form_field, key: :api_key, errors:).render do %>
-    <label class="key">
+    <label class="key" for="device[api_key]">
       API Key
-      <%= tag.input name: "device[api_key]",
-                    type: :password,
-                    value: field_for(:api_key, fields, device),
-                    class: :value %>
+      <%= render "field_popover_trigger", name: "api_key" %>
     </label>
+
+    <%= tag.input name: "device[api_key]",
+                  type: :password,
+                  value: field_for(:api_key, fields, device),
+                  class: :value %>
+
   <% end %>
+
+  <%= render "field_popover_content",
+             name: "api_key",
+             label: "API Key",
+             body: "Used for API requests to authenticate between server and device." %>
 
   <%= scope(:form_field, key: :refresh_rate, errors:).render do %>
-    <label class="key">
+    <label class="key" for="device[refresh_rate]">
       Refresh Rate
-      <%= tag.input name: "device[refresh_rate]",
-                    value: field_for(:refresh_rate, fields, device),
-                    class: :value,
-                    autocomplete: :refresh_rate %>
+      <%= render "field_popover_trigger", name: "refresh_rate" %>
     </label>
+
+    <%= tag.input name: "device[refresh_rate]",
+                  type: :number,
+                  value: field_for(:refresh_rate, fields, device),
+                  class: :value,
+                  autocomplete: :refresh_rate %>
   <% end %>
 
+  <%= render "field_popover_content",
+             name: "refresh_rate",
+             label: "Refresh Rate",
+             body: "The time, in seconds, until the next image is displayed on your device." %>
+
   <%= scope(:form_field, key: :image_timeout, errors:).render do %>
-    <label class="key">
+    <label class="key" for="device[image_timeout]">
       Image Timeout
-      <%= tag.input name: "device[image_timeout]",
-                    value: field_for(:image_timeout, fields, device),
-                    class: :value,
-                    autocomplete: :image_timeout %>
+      <%= render "field_popover_trigger", name: "image_timeout" %>
     </label>
+
+    <%= tag.input name: "device[image_timeout]",
+                  type: :number,
+                  value: field_for(:image_timeout, fields, device),
+                  class: :value,
+                  autocomplete: :image_timeout %>
   <% end %>
+
+  <%= render "field_popover_content",
+             name: "image_timeout",
+             label: "Image Timeout",
+             body: "The time, in seconds, to fetch the image before timing out (useful if you are making an external request for an image)." %>
 </fieldset>

--- a/app/templates/devices/show.html.erb
+++ b/app/templates/devices/show.html.erb
@@ -16,7 +16,6 @@
     <div class="page-actions">
       <%= link_to "Logs", "/devices/#{device.id}/logs" %>
       <%= render "edit_link", device: %>
-      <%= render "delete_link", device: %>
     </div>
 
     <dl class="site-definition-list">

--- a/app/templates/devices/show.html.erb
+++ b/app/templates/devices/show.html.erb
@@ -29,13 +29,13 @@
       <dd class="value"><%= device.friendly_id %></dd>
 
       <dt class="key">MAC Address</dt>
-      <dd class="value"><%= device.mac_address %></dd>
+      <dd class="value site-secret"><%= device.mac_address %></dd>
 
       <dt class="key">Proxy</dt>
       <dd class="value"><%= device.proxy %></dd>
 
       <dt class="key">API Key</dt>
-      <dd class="value"><%= device.api_key %></dd>
+      <dd class="value site-secret"><%= device.api_key %></dd>
 
       <dt class="key">Refresh Rate</dt>
       <dd class="value"><%= device.refresh_rate %></dd>

--- a/bin/setup
+++ b/bin/setup
@@ -59,7 +59,8 @@ class Runner
 
     path.write %(web: rerun --dir app,config,lib,slices --pattern="**/*.{erb,rb}" -- ) +
                "bundle exec puma --config ./config/puma.rb\n" \
-               "assets: bundle exec hanami assets watch"
+               "assets: bundle exec hanami assets watch\n" \
+               "poller: bin/screen_poller"
   end
 end
 


### PR DESCRIPTION
## Overview

This is a bit more of a mixed bag but, for the most part, this provides more information when managing a device so you have a better idea of what each form field is for and why it's important. There is some CSS styling for bluring sensitive information which is super helpful for screenshot/screencasting purposes. I've also wired in the device display poller for acquring images from Core for devices that are setup to proxy.

## Screenshots/Screencasts

![2025-04-03_17-06-45-Orion](https://github.com/user-attachments/assets/c66c1005-dcae-46e1-b258-2749ca19730f)

https://github.com/user-attachments/assets/901c32a2-fbc9-43de-bf7c-edbbcebef901

## Details

- See comments for details.
- Circle CI is down, at the moment, so will have to wait until it's back up to rebase this work.