### PR TITLE
Added API client firmware endpoint

### DIFF
--- a/config/settings.rb
+++ b/config/settings.rb
@@ -12,5 +12,9 @@ module Terminus
     setting :screens_root,
             constructor: Types::Params::String,
             default: Hanami.app.root.join("public/assets/screens").to_s
+
+    setting :firmware_root,
+            constructor: Types::Params::String,
+            default: Hanami.app.root.join("public/assets/firmware").to_s
   end
 end

--- a/lib/terminus/endpoints/container.rb
+++ b/lib/terminus/endpoints/container.rb
@@ -13,11 +13,13 @@ module Terminus
       namespace :contracts do
         register :current_screen, CurrentScreen::Contract
         register :display, Display::Contract
+        register :firmware, Firmware::Contract
       end
 
       namespace :responses do
         register :current_screen, CurrentScreen::Response
         register :display, Display::Response
+        register :firmware, Firmware::Response
       end
     end
   end

--- a/lib/terminus/endpoints/firmware/contract.rb
+++ b/lib/terminus/endpoints/firmware/contract.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "dry/schema"
+
+module Terminus
+  module Endpoints
+    module Firmware
+      # Defines API response contract.
+      Contract = Dry::Schema.JSON do
+        required(:url).filled :string
+        required(:version).filled :string
+      end
+    end
+  end
+end

--- a/lib/terminus/endpoints/firmware/requester.rb
+++ b/lib/terminus/endpoints/firmware/requester.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "pipeable"
+
+module Terminus
+  module Endpoints
+    module Firmware
+      # Acquires API repsonse.
+      class Requester
+        include Dependencies[
+          :client,
+          contract: "contracts.firmware",
+          response: "responses.firmware"
+        ]
+
+        include Pipeable
+
+        def call
+          pipe client.get("firmware/latest"),
+               try(:parse, catch: JSON::ParserError),
+               validate(contract, as: :to_h),
+               to(response, :for)
+        end
+      end
+    end
+  end
+end

--- a/lib/terminus/endpoints/firmware/response.rb
+++ b/lib/terminus/endpoints/firmware/response.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Endpoints
+    module Firmware
+      # Models API response.
+      Response = Data.define :url, :version do
+        def self.for(attributes) = new(**attributes)
+      end
+    end
+  end
+end

--- a/spec/lib/terminus/endpoints/firmware/requester_spec.rb
+++ b/spec/lib/terminus/endpoints/firmware/requester_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Endpoints::Firmware::Requester do
+  subject(:requester) { described_class.new client: }
+
+  let(:client) { Terminus::API::Client.new http: }
+
+  describe "#call" do
+    let :http do
+      HTTP::Fake::Client.new do
+        get "/api/firmware/latest" do
+          headers["Content-Type"] = "application/json"
+          status 200
+
+          <<~JSON
+            {
+              "url": "https://test.io/FW1.2.3.bin",
+              "version": "1.2.3"
+            }
+          JSON
+        end
+      end
+    end
+
+    it "answers success" do
+      response = requester.call
+
+      expect(response).to be_success(
+        Terminus::Endpoints::Firmware::Response[
+          url: "https://test.io/FW1.2.3.bin",
+          version: "1.2.3"
+        ]
+      )
+    end
+  end
+end

--- a/spec/lib/terminus/endpoints/firmware/response_spec.rb
+++ b/spec/lib/terminus/endpoints/firmware/response_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Endpoints::Firmware::Response do
+  describe ".for" do
+    it "answers record for attributes" do
+      attributes = {url: "https://test.io/FW1.0.0.bin", version: "1.0.0"}
+      expect(described_class.for(attributes)).to eq(described_class[**attributes])
+    end
+  end
+end


### PR DESCRIPTION
## Overview

This following allows this app to obtain the latest firmware from Core for updating local devices. This provides the plumbing for that to be made possible.

## Details

- See commits for details.