### PR TITLE
Fixed screen asset polling and downloading

### DIFF
--- a/app/aspects/screens/downloader.rb
+++ b/app/aspects/screens/downloader.rb
@@ -18,7 +18,7 @@ module Terminus
           at = oldest_at
 
           get(uri).fmap do |content|
-            Pathname(settings.screens_root).join(file_name).write(content).touch at
+            Pathname(settings.screens_root).mkpath.join(file_name).write(content).touch at
           end
         end
 

--- a/app/aspects/screens/poller.rb
+++ b/app/aspects/screens/poller.rb
@@ -16,13 +16,25 @@ module Terminus
         ]
 
         def call
+          watch_for_shudown
+          keep_alive
+        end
+
+        private
+
+        def watch_for_shudown
+          kernel.trap "INT" do
+            kernel.puts "Gracefully shutting down polling..."
+            kernel.exit
+          end
+        end
+
+        def keep_alive
           kernel.loop do
             process_devices
             kernel.sleep seconds
           end
         end
-
-        private
 
         def process_devices
           repository.all.select(&:proxy).each { |device| process device }

--- a/lib/terminus/screens/toucher.rb
+++ b/lib/terminus/screens/toucher.rb
@@ -3,10 +3,12 @@
 require "refinements/pathname"
 
 module Terminus
-  # Touches the oldest file to make it the latest file.
+  # Makes the oldest file the newest file.
   module Screens
     using Refinements::Pathname
 
-    Toucher = -> root { Pathname(root).files.min_by(&:mtime).touch }
+    Toucher = lambda do |root|
+      Pathname(root).files.min_by(&:mtime).then { it.touch if it }
+    end
   end
 end

--- a/spec/app/aspects/screens/downloader_spec.rb
+++ b/spec/app/aspects/screens/downloader_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Terminus::Aspects::Screens::Downloader do
   describe "#call" do
     before { allow(settings).to receive(:screens_root).and_return temp_dir }
 
+    it "creates root directory when it doesn't exist" do
+      temp_dir.rmdir
+      downloader.call "https://usetrmnl.com/assets/mashups.png", "test.png"
+      expect(temp_dir.exist?).to be(true)
+    end
+
     it "downloads file" do
       downloader.call "https://usetrmnl.com/assets/mashups.png", "test.png"
       expect(temp_dir.join("test.png").exist?).to be(true)

--- a/spec/lib/terminus/screens/toucher_spec.rb
+++ b/spec/lib/terminus/screens/toucher_spec.rb
@@ -33,5 +33,10 @@ RSpec.describe Terminus::Screens::Toucher do
 
       expect(all.sort_by(&:mtime)).to eq([three, one, two])
     end
+
+    it "answers nil if there is nothing to touch" do
+      toucher.call temp_dir
+      expect(toucher.call(temp_dir)).to be(nil)
+    end
   end
 end


### PR DESCRIPTION
## Overview

These issues cropped up when Seyoung was setting up this app for the first time and I noticed the stack dump related to the screen poller wasn't behaving gracefully in all situations. These changes ensure that screen downloading and polling is more robust for a better user experience.

## Screenshots/Screencasts

The following shows how clean all processes are now when gracefully shutting down:

![2025-04-07_14-42-31-iTerm2](https://github.com/user-attachments/assets/dcbcde1c-56be-464f-a060-203e870cd46d)

## Details

- See commits for details.