### PR TITLE
Added device firmware update toggle

### DIFF
--- a/app/contracts/api/device.rb
+++ b/app/contracts/api/device.rb
@@ -13,12 +13,17 @@ module Terminus
         required(:refresh_rate).filled :integer
         required(:image_timeout).filled :integer
         optional(:proxy).filled :bool
+        optional(:firmware_update).filled :bool
 
         after :value_coercer do |result|
           next unless result.output
-          next result if result.key? :proxy
 
-          result.to_h.tap { it[:proxy] = false }
+          attributes = result.to_h
+
+          attributes[:proxy] = false unless result.key? :proxy
+          attributes[:firmware_update] = false unless result.key? :firmware_update
+
+          attributes
         end
       end
     end

--- a/app/structs/device.rb
+++ b/app/structs/device.rb
@@ -4,7 +4,9 @@ module Terminus
   module Structs
     # The device struct.
     class Device < DB::Struct
-      def as_api_display = {image_url_timeout: image_timeout, refresh_rate:}
+      def as_api_display
+        {image_url_timeout: image_timeout, refresh_rate:, update_firmware: firmware_update}
+      end
     end
   end
 end

--- a/app/templates/devices/_fields.html.erb
+++ b/app/templates/devices/_fields.html.erb
@@ -43,23 +43,6 @@
              label: "MAC Address",
              body: "Uniquely identifies your device when communicating over the network." %>
 
-  <%= scope(:form_field, key: :proxy, errors:).render do %>
-    <label class="key" for="device[proxy]">
-      Proxy
-      <%= render "field_popover_trigger", name: "proxy" %>
-    </label>
-
-    <%= tag.input name: "device[proxy]",
-                  type: :checkbox,
-                  checked: field_for(:proxy, fields, device),
-                  switch: true,
-                  class: :value %>
-  <% end %>
-
-  <%= render "field_popover_content",
-             name: "proxy",
-             label: "Proxy",
-             body: "Allows you to display remote images generated via your TRMNL account when enabled. This includes locally generated images but the remote images will take precedence. Your MAC address and API key must be identical both locally and remotely for this to work." %>
 
   <%= scope(:form_field, key: :api_key, errors:).render do %>
     <label class="key" for="device[api_key]">
@@ -78,6 +61,42 @@
              name: "api_key",
              label: "API Key",
              body: "Used for API requests to authenticate between server and device." %>
+
+  <%= scope(:form_field, key: :firmware_update, errors:).render do %>
+    <label class="key" for="device[firmware_update]">
+      Firmware Update
+      <%= render "field_popover_trigger", name: "firmware_update" %>
+    </label>
+
+    <%= tag.input name: "device[firmware_update]",
+                  type: :checkbox,
+                  checked: field_for(:firmware_update, fields, device),
+                  switch: true,
+                  class: :value %>
+  <% end %>
+
+  <%= render "field_popover_content",
+             name: "firmware_update",
+             label: "Firmware Update",
+             body: "When enabled, allows your device to be automatically updated when a new firmware version is available. At the moment, you'll want to immediately disable this once you see your device being updated or it'll go into an infinite update loop. This due to a firmware bug." %>
+
+  <%= scope(:form_field, key: :proxy, errors:).render do %>
+    <label class="key" for="device[proxy]">
+      Proxy
+      <%= render "field_popover_trigger", name: "proxy" %>
+    </label>
+
+    <%= tag.input name: "device[proxy]",
+                  type: :checkbox,
+                  checked: field_for(:proxy, fields, device),
+                  switch: true,
+                  class: :value %>
+  <% end %>
+
+  <%= render "field_popover_content",
+             name: "proxy",
+             label: "Proxy",
+             body: "Allows you to display remote images generated via your TRMNL account when enabled. This includes locally generated images but the remote images will take precedence. Your MAC address and API key must be identical both locally and remotely for this to work." %>
 
   <%= scope(:form_field, key: :refresh_rate, errors:).render do %>
     <label class="key" for="device[refresh_rate]">

--- a/app/templates/devices/show.html.erb
+++ b/app/templates/devices/show.html.erb
@@ -49,6 +49,9 @@
       <dt class="key">Firmware</dt>
       <dd class="value"><%= device.firmware_version %></dd>
 
+      <dt class="key">Firmware Update</dt>
+      <dd class="value"><%= device.firmware_update %></dd>
+
       <dt class="key">Firmware Beta</dt>
       <dd class="value"><%= device.firmware_beta %></dd>
 

--- a/config/db/migrate/20250408143435_add_device_firmware_update_column.rb
+++ b/config/db/migrate/20250408143435_add_device_firmware_update_column.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ROM::SQL.migration do
+  change { add_column :devices, :firmware_update, :boolean, null: false, default: false }
+end

--- a/config/db/structure.sql
+++ b/config/db/structure.sql
@@ -134,7 +134,8 @@ CREATE TABLE public.devices (
     setup_at timestamp without time zone,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    proxy boolean
+    proxy boolean,
+    firmware_update boolean DEFAULT false NOT NULL
 );
 
 
@@ -230,4 +231,5 @@ SET search_path TO "$user", public;
 INSERT INTO schema_migrations (filename) VALUES
 ('20250305150912_create_devices.rb'),
 ('20250324153748_create_device_logs.rb'),
-('20250401150503_add_device_proxy_column.rb');
+('20250401150503_add_device_proxy_column.rb'),
+('20250408143435_add_device_firmware_update_column.rb');

--- a/spec/app/actions/api/display/show_spec.rb
+++ b/spec/app/actions/api/display/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
   using Refinements::Pathname
 
   subject :action do
-    described_class.new settings:, fetcher: Terminus::Aspects::Screens::Rotator.new(settings:)
+    described_class.new settings:, image_fetcher: Terminus::Aspects::Screens::Rotator.new(settings:)
   end
 
   include_context "with firmware headers"
@@ -19,8 +19,8 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
 
     before do
       firmware_headers["HTTP_ACCESS_TOKEN"] = device.api_key
-      allow(settings).to receive(:screens_root).and_return(temp_dir)
-
+      allow(settings).to receive_messages(screens_root: temp_dir, firmware_root: temp_dir)
+      temp_dir.join("0.0.0.bin").touch
       SPEC_ROOT.join("support/fixtures/test.bmp").copy temp_dir.join("test.bmp")
     end
 
@@ -31,7 +31,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
 
       expect(payload).to include(
         filename: /.+\.bmp/,
-        firmware_url: nil,
+        firmware_url: /.*0\.0\.0\.bin/,
         image_url: %r(http://.+/assets/screens/.+\.bmp),
         image_url_timeout: 0,
         refresh_rate: 900,
@@ -51,7 +51,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
 
         expect(payload).to include(
           filename: /.+\.bmp/,
-          firmware_url: nil,
+          firmware_url: /.*0\.0\.0\.bin/,
           image_url: %r(http://.+/assets/screens/.+\.bmp),
           image_url_timeout: 10,
           refresh_rate: 20,
@@ -68,7 +68,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
 
       expect(payload).to include(
         filename: /.+\.bmp/,
-        firmware_url: nil,
+        firmware_url: /.*0\.0\.0\.bin/,
         image_url: %r(http://.+/assets/screens/.+\.bmp),
         image_url_timeout: 0,
         refresh_rate: 900,
@@ -85,7 +85,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
 
       expect(payload).to include(
         filename: /.+\.bmp/,
-        firmware_url: nil,
+        firmware_url: /.*0\.0\.0\.bin/,
         image_url: %r(data:image/bmp;base64.+),
         image_url_timeout: 0,
         refresh_rate: 900,
@@ -103,7 +103,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
 
       expect(payload).to include(
         filename: /.+\.bmp/,
-        firmware_url: nil,
+        firmware_url: /\d+\.\d+\.\d+\.bin/,
         image_url: %r(data:image/bmp;base64.+),
         image_url_timeout: 0,
         refresh_rate: 900,

--- a/spec/app/contracts/api/device_spec.rb
+++ b/spec/app/contracts/api/device_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Terminus::Contracts::API::Device do
         api_key: "secret",
         refresh_rate: 100,
         image_timeout: 0,
-        proxy: "on"
+        proxy: "on",
+        firmware_update: "on"
       }
     end
 
@@ -29,6 +30,15 @@ RSpec.describe Terminus::Contracts::API::Device do
     it "answers false when proxy key is missing" do
       attributes.delete :proxy
       expect(described_class.call(attributes).to_h).to include(proxy: false)
+    end
+
+    it "answers true when firmware update is truthy" do
+      expect(described_class.call(attributes).to_h).to include(firmware_update: true)
+    end
+
+    it "answers false when firmware update key is missing" do
+      attributes.delete :firmware_update
+      expect(described_class.call(attributes).to_h).to include(firmware_update: false)
     end
   end
 end

--- a/spec/app/structs/device_spec.rb
+++ b/spec/app/structs/device_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe Terminus::Structs::Device, :db do
 
   describe "#as_api_display" do
     it "answers display specific attributes" do
-      expect(device.as_api_display).to eq(image_url_timeout: 10, refresh_rate: 20)
+      expect(device.as_api_display).to eq(
+        image_url_timeout: 10,
+        refresh_rate: 20,
+        update_firmware: false
+      )
     end
   end
 end


### PR DESCRIPTION
## Overview

This completes work for being able to update your device firmware by simplying toggling the _FIrmware Update_ option on/off when editing your device. When enabled, the next time the device hits the `/api/display` endoint, it'll be updated to pull down the latest firmware version and update accordingly.

## Screenshots/Screencasts

https://github.com/user-attachments/assets/e168e31c-a5f8-4bd9-9148-0dda137f3367

## Details

- See commits for details.
- There is a firmware bug that causes the firmware update to go into an infinite loop that I'll be logging next. You can prevent this by manually disabling the firmware update after you see yoru device being updated (this also in the form documentation too).