### PR TITLE
Refactored namespaces and dependencies

### DIFF
--- a/app/actions/api/log/create.rb
+++ b/app/actions/api/log/create.rb
@@ -8,12 +8,9 @@ module Terminus
         class Create < Terminus::Action
           include Deps[
             :logger,
+            transformer: "aspects.api.transformers.firmware_log",
             device_repository: "repositories.device",
-            log_repository: "repositories.device_log"
-          ]
-
-          include Initable[
-            transformer: proc { Terminus::Aspects::API::Transformers::FirmwareLog.new }
+            log_repository: "repositories.device_log",
           ]
 
           format :json

--- a/app/aspects/screens/downloader.rb
+++ b/app/aspects/screens/downloader.rb
@@ -9,7 +9,7 @@ module Terminus
       class Downloader
         include Deps[:settings]
         include Dependencies[client: :http]
-        include Initable[offset: 10] # Seconds.
+        include Initable[seconds: 10]
         include Dry::Monads[:result]
 
         using Refinements::Pathname
@@ -27,7 +27,7 @@ module Terminus
 
           return Time.now unless oldest_file
 
-          oldest_file.mtime - offset
+          oldest_file.mtime - seconds
         end
 
         def get uri

--- a/app/aspects/screens/poller.rb
+++ b/app/aspects/screens/poller.rb
@@ -5,12 +5,10 @@ module Terminus
     module Screens
       # Polls the Core Display API on a scheduled interval for new images to display locally.
       class Poller
-        include Deps[repository: "repositories.device"]
+        include Deps["aspects.screens.downloader", repository: "repositories.device"]
 
-        # :nocov:
         include Initable[
           endpoint: proc { Terminus::Endpoints::Display::Requester.new },
-          downloader: proc { Terminus::Aspects::Screens::Downloader.new },
           kernel: Kernel,
           seconds: 300
         ]
@@ -24,7 +22,7 @@ module Terminus
 
         def watch_for_shudown
           kernel.trap "INT" do
-            kernel.puts "Gracefully shutting down polling..."
+            kernel.puts "Gracefully shutting down screen polling..."
             kernel.exit
           end
         end

--- a/app/aspects/screens/rotator.rb
+++ b/app/aspects/screens/rotator.rb
@@ -1,26 +1,19 @@
 # frozen_string_literal: true
 
+require "initable"
+
 module Terminus
   module Aspects
     module Screens
       # Rotates and fetches images for rendering on a device.
       class Rotator
-        include Deps[:settings]
-
-        def initialize(toucher: Terminus::Screens::Toucher, fetcher: Fetcher.new, **)
-          @toucher = toucher
-          @fetcher = fetcher
-          super(**)
-        end
+        include Deps[:settings, "aspects.screens.fetcher"]
+        include Initable[toucher: proc { Terminus::Screens::Toucher }]
 
         def call images_uri:, encryption: nil
           fetcher.call(images_uri:, encryption:)
                  .tap { toucher.call settings.screens_root }
         end
-
-        private
-
-        attr_reader :toucher, :fetcher
       end
     end
   end

--- a/app/aspects/synchronizers/device.rb
+++ b/app/aspects/synchronizers/device.rb
@@ -9,7 +9,7 @@ module Terminus
     module Synchronizers
       # Updates device based on firmware header information.
       class Device
-        include Initable[firmware_parser: proc { Terminus::HTTP::Headers::Parser.new }]
+        include Initable[firmware_parser: proc { Terminus::API::Headers::Parser.new }]
         include Deps[:settings, repository: "repositories.device"]
         include Pipeable
         include Dry::Monads[:result]

--- a/lib/terminus/api/headers/contract.rb
+++ b/lib/terminus/api/headers/contract.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Terminus
-  module HTTP
+  module API
     module Headers
       Contract = Dry::Schema.Params do
         required(:HTTP_ACCESS_TOKEN).maybe :string

--- a/lib/terminus/api/headers/model.rb
+++ b/lib/terminus/api/headers/model.rb
@@ -3,7 +3,7 @@
 require "refinements/hash"
 
 module Terminus
-  module HTTP
+  module API
     module Headers
       KEY_MAP = {
         HTTP_ACCESS_TOKEN: :api_key,

--- a/lib/terminus/api/headers/parser.rb
+++ b/lib/terminus/api/headers/parser.rb
@@ -4,11 +4,11 @@ require "initable"
 require "pipeable"
 
 module Terminus
-  module HTTP
+  module API
     module Headers
       # Parses firmware specific HTTP headers.
       class Parser
-        include Initable[contract: proc { Terminus::HTTP::Headers::Contract }, model: Model]
+        include Initable[contract: proc { Terminus::API::Headers::Contract }, model: Model]
         include Pipeable
 
         def call(headers) = pipe headers, validate(contract, as: :to_h), to(model, :for)

--- a/lib/terminus/lib_container.rb
+++ b/lib/terminus/lib_container.rb
@@ -10,8 +10,8 @@ module Terminus
     extend Containable
 
     register :http do
-      ::HTTP.default_options = ::HTTP::Options.new features: {logging: {logger: self[:logger]}}
-      ::HTTP
+      HTTP.default_options = ::HTTP::Options.new features: {logging: {logger: self[:logger]}}
+      HTTP
     end
 
     register(:logger) { Cogger.new id: :terminus, formatter: :json }

--- a/spec/app/actions/dashboard/show_spec.rb
+++ b/spec/app/actions/dashboard/show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Terminus::Actions::Dashboard::Show, :db do
 
     it "lists IP addresses" do
       response = action.call Hash.new
-      expect(response.body.first).to include(/\d+\.\d+\.\d+ \(wired\)/)
+      expect(response.body.first).to include(%r(<li.+\d+\.\d+\.\d+.+</li>))
     end
 
     it "lists firmware" do

--- a/spec/lib/terminus/api/headers/contract_spec.rb
+++ b/spec/lib/terminus/api/headers/contract_spec.rb
@@ -2,7 +2,7 @@
 
 require "hanami_helper"
 
-RSpec.describe Terminus::HTTP::Headers::Contract do
+RSpec.describe Terminus::API::Headers::Contract do
   using Versionaire::Cast
 
   subject(:contract) { described_class }

--- a/spec/lib/terminus/api/headers/model_spec.rb
+++ b/spec/lib/terminus/api/headers/model_spec.rb
@@ -3,7 +3,7 @@
 require "hanami_helper"
 require "versionaire"
 
-RSpec.describe Terminus::HTTP::Headers::Model do
+RSpec.describe Terminus::API::Headers::Model do
   using Refinements::Hash
   using Versionaire::Cast
 

--- a/spec/lib/terminus/api/headers/parser_spec.rb
+++ b/spec/lib/terminus/api/headers/parser_spec.rb
@@ -3,7 +3,7 @@
 require "hanami_helper"
 require "versionaire"
 
-RSpec.describe Terminus::HTTP::Headers::Parser do
+RSpec.describe Terminus::API::Headers::Parser do
   using Versionaire::Cast
 
   subject(:parser) { described_class.new }
@@ -13,7 +13,7 @@ RSpec.describe Terminus::HTTP::Headers::Parser do
   describe "#call" do
     it "answers header record when success" do
       expect(parser.call(firmware_headers)).to be_success(
-        Terminus::HTTP::Headers::Model[
+        Terminus::API::Headers::Model[
           host: "https://localhost",
           user_agent: "ESP32HTTPClient",
           mac_address: "A1:B2:C3:D4:E5:F6",
@@ -32,7 +32,7 @@ RSpec.describe Terminus::HTTP::Headers::Parser do
       firmware_headers.delete "HTTP_ID"
 
       expect(parser.call(firmware_headers)).to be_failure(
-        Terminus::HTTP::Headers::Contract.call(firmware_headers)
+        Terminus::API::Headers::Contract.call(firmware_headers)
       )
     end
   end


### PR DESCRIPTION
## Overview

This is mostly a bit of cleanup to reduce lines of code, collapse namespaces, and clean up the dependnecies being injected.

## Details

- See commits for details.