### PR TITLE
Added screens API endpoint

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -5,7 +5,7 @@ exclude_paths:
 detectors:
   FeatureEnvy:
     exclude:
-      - Terminus::Actions::API::Images::Create#handle
+      - Terminus::Actions::API::Screens::Create#handle
       - Terminus::Screens::Greyscaler#convert
       - Terminus::Screens::Screensaver#save
   LongParameterList:

--- a/README.adoc
+++ b/README.adoc
@@ -249,6 +249,41 @@ curl "https://localhost:2443/api/setup/" \
 ----
 ====
 
+==== Screens
+
+Used for generating new device screens by supplying HTML content for rendering, screenshotting, and grey scaling to render properly on your device.
+
+.Request
+[%collapsible]
+====
+[source,bash]
+----
+curl -X "POST" "https://localhost:2443/api/screens" \
+    -H 'Access-Token: <redacted>' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d $'{
+ "image": {
+   "content": "<p>Test</p>"
+   "file_name": "test"
+ }
+}'
+----
+
+The `Access-Token` is your device's MAC address. You can obtain this information from the UI.
+====
+
+.Response
+[%collapsible]
+====
+[source,json]
+----
+{
+  "path": "$HOME/Engineering/terminus/public/assets/screens/A1B2C3D4E5F6/test.bmp"
+}
+----
+====
+
 ==== Logs
 
 Uses for logging information about your server and/or device. Mostly used for debugging purposes.
@@ -299,43 +334,6 @@ curl -X "POST" "https://localhost:2443/api/log" \
 ====
 Logs details and answers a HTTP 204 status with no content.
 ====
-
-==== Images
-
-Used for generating new images by supplying HTML content for rendering, screenshotting, and grey scaling to render properly on your device.
-
-.Request
-[%collapsible]
-====
-[source,bash]
-----
-curl -X "POST" "https://localhost:2443/api/images" \
-    -H 'ID: <redacted>' \
-    -H 'Access-Token: <redacted>' \
-    -H 'Accept: application/json' \
-    -H 'Content-Type: application/json' \
-    -d $'{
- "image": {
-   "content": "<p>Test</p>"
-   "file_name": "test"
- }
-}'
-----
-
-The `ID` header is your device's MAC address. You can obtain this information from the UI.
-====
-
-.Response
-[%collapsible]
-====
-[source,json]
-----
-{
-  "path": "$HOME/Engineering/terminus/public/assets/screens/test.bmp"
-}
-----
-====
-
 
 💡 The images API supports full HTML so you can supply CSS styles, full DOM, etc. At a minimum, you'll want to use the following to prevent white borders showing up around your generated screens:
 

--- a/app/actions/api/screens/create.rb
+++ b/app/actions/api/screens/create.rb
@@ -6,7 +6,7 @@ require "refinements/pathname"
 module Terminus
   module Actions
     module API
-      module Images
+      module Screens
         # The create action.
         class Create < Terminus::Action
           include Deps[:settings]

--- a/app/repositories/device.rb
+++ b/app/repositories/device.rb
@@ -14,11 +14,15 @@ module Terminus
       def find(id) = (devices.by_pk(id).one if id)
 
       def find_by_api_key value
+        return unless value
+
         devices.where { api_key.ilike "%#{value}%" }
                .one
       end
 
       def find_by_mac_address value
+        return unless value
+
         devices.where { mac_address.ilike "%#{value}%" }
                .one
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ module Terminus
     get "/", to: "dashboard.show"
 
     get "/api/display/", to: "api.display.show", as: :api_display_show
-    post "/api/images", to: "api.images.create", as: :api_images_create
+    post "/api/screens", to: "api.screens.create", as: :api_screens_create
     post "/api/log", to: "api.log.create", as: :api_log_create
     get "/api/setup/", to: "api.setup.show", as: :api_setup_show
 

--- a/spec/app/actions/api/display/show_spec.rb
+++ b/spec/app/actions/api/display/show_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
     described_class.new settings:, image_fetcher: Terminus::Aspects::Screens::Rotator.new(settings:)
   end
 
+  include_context "with main application"
   include_context "with firmware headers"
-  include_context "with temporary directory"
 
   let(:settings) { Hanami.app[:settings] }
 
@@ -18,7 +18,6 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
     let(:device) { Factory[:device] }
 
     before do
-      allow(settings).to receive_messages(screens_root: temp_dir, firmware_root: temp_dir)
       temp_dir.join("0.0.0.bin").touch
 
       SPEC_ROOT.join("support/fixtures/test.bmp")
@@ -33,7 +32,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
       expect(payload).to include(
         filename: /.+\.bmp/,
         firmware_url: /.*0\.0\.0\.bin/,
-        image_url: %r(http://.+/assets/screens/A1B2C3D4E5F6.+\.bmp),
+        image_url: %r(https://.+/assets/screens/A1B2C3D4E5F6.+\.bmp),
         image_url_timeout: 0,
         refresh_rate: 900,
         reset_firmware: false,
@@ -53,7 +52,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
         expect(payload).to include(
           filename: /.+\.bmp/,
           firmware_url: /.*0\.0\.0\.bin/,
-          image_url: %r(http://.+/assets/screens/A1B2C3D4E5F6.+\.bmp),
+          image_url: %r(https://.+/assets/screens/A1B2C3D4E5F6.+\.bmp),
           image_url_timeout: 10,
           refresh_rate: 20,
           reset_firmware: false,
@@ -70,7 +69,7 @@ RSpec.describe Terminus::Actions::API::Display::Show, :db do
       expect(payload).to include(
         filename: /.+\.bmp/,
         firmware_url: /.*0\.0\.0\.bin/,
-        image_url: %r(http://.+/assets/screens/A1B2C3D4E5F6.+\.bmp),
+        image_url: %r(https://.+/assets/screens/A1B2C3D4E5F6.+\.bmp),
         image_url_timeout: 0,
         refresh_rate: 900,
         reset_firmware: false,

--- a/spec/app/actions/api/screens/create_spec.rb
+++ b/spec/app/actions/api/screens/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "hanami_helper"
 
-RSpec.describe Terminus::Actions::API::Images::Create do
+RSpec.describe Terminus::Actions::API::Screens::Create do
   subject(:action) { described_class.new settings: }
 
   include_context "with temporary directory"

--- a/spec/app/actions/api/screens/create_spec.rb
+++ b/spec/app/actions/api/screens/create_spec.rb
@@ -5,12 +5,9 @@ require "hanami_helper"
 RSpec.describe Terminus::Actions::API::Screens::Create do
   subject(:action) { described_class.new settings: }
 
-  include_context "with temporary directory"
+  include_context "with main application"
 
-  let(:settings) { Hanami.app[:settings] }
   let(:path) { temp_dir.join "rspec_test.bmp" }
-
-  before { allow(settings).to receive(:screens_root).and_return temp_dir }
 
   describe "#call" do
     it "creates image with random name" do

--- a/spec/app/actions/dashboard/show_spec.rb
+++ b/spec/app/actions/dashboard/show_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe Terminus::Actions::Dashboard::Show, :db do
 
   subject(:action) { described_class.new settings: }
 
-  include_context "with temporary directory"
-
-  let(:settings) { Hanami.app[:settings] }
+  include_context "with main application"
 
   describe "#call" do
     let(:device) { Factory[:device] }
@@ -27,7 +25,6 @@ RSpec.describe Terminus::Actions::Dashboard::Show, :db do
 
     it "lists firmware" do
       temp_dir.join("0.0.0.bin").touch
-      allow(settings).to receive(:firmware_root).and_return temp_dir
       response = action.call Hash.new
 
       expect(response.body.first).to include(%(<a href="../tmp/rspec/0.0.0.bin">0.0.0</a>))

--- a/spec/app/aspects/firmware/downloader_spec.rb
+++ b/spec/app/aspects/firmware/downloader_spec.rb
@@ -7,10 +7,8 @@ RSpec.describe Terminus::Aspects::Firmware::Downloader do
 
   subject(:downloader) { described_class.new http:, endpoint: }
 
+  include_context "with main application"
   include_context "with library dependencies"
-  include_context "with temporary directory"
-
-  let(:settings) { Hanami.app[:settings] }
 
   let :endpoint do
     instance_double Terminus::Endpoints::Firmware::Requester,
@@ -23,8 +21,6 @@ RSpec.describe Terminus::Aspects::Firmware::Downloader do
   end
 
   describe "#call" do
-    before { allow(settings).to receive(:firmware_root).and_return temp_dir }
-
     context "with success" do
       let(:http) { HTTP }
 

--- a/spec/app/aspects/firmware/fetcher_spec.rb
+++ b/spec/app/aspects/firmware/fetcher_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe Terminus::Aspects::Firmware::Fetcher do
 
   subject(:finder) { described_class.new settings: }
 
-  include_context "with temporary directory"
-
-  let(:settings) { Hanami.app[:settings] }
-
-  before { allow(settings).to receive(:firmware_root).and_return temp_dir }
+  include_context "with main application"
 
   describe "#call" do
     it "answers latest firmware version" do

--- a/spec/app/aspects/screens/downloader_spec.rb
+++ b/spec/app/aspects/screens/downloader_spec.rb
@@ -5,16 +5,13 @@ require "hanami_helper"
 RSpec.describe Terminus::Aspects::Screens::Downloader do
   using Refinements::Pathname
 
-  subject(:downloader) { described_class.new client: }
+  subject(:downloader) { described_class.new settings:, client: }
 
-  include_context "with temporary directory"
+  include_context "with main application"
 
   let(:client) { HTTP }
-  let(:settings) { Hanami.app[:settings] }
 
   describe "#call" do
-    before { allow(settings).to receive(:screens_root).and_return temp_dir }
-
     it "creates root directory when it doesn't exist" do
       temp_dir.rmdir
       downloader.call "https://usetrmnl.com/assets/mashups.png", "abc/test.png"

--- a/spec/app/aspects/screens/fetcher_spec.rb
+++ b/spec/app/aspects/screens/fetcher_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe Terminus::Aspects::Screens::Fetcher do
 
   subject(:fetcher) { described_class.new settings: }
 
-  include_context "with temporary directory"
-
-  let(:settings) { Hanami.app[:settings] }
-
-  before { allow(settings).to receive_messages screens_root: temp_dir, api_uri: "https://localhost" }
+  include_context "with main application"
 
   describe "#call" do
     let(:fixture_path) { SPEC_ROOT.join "support/fixtures/test.bmp" }

--- a/spec/app/aspects/screens/rotator_spec.rb
+++ b/spec/app/aspects/screens/rotator_spec.rb
@@ -7,13 +7,7 @@ RSpec.describe Terminus::Aspects::Screens::Rotator do
 
   subject(:rotator) { described_class.new settings: }
 
-  include_context "with temporary directory"
-
-  let(:settings) { Hanami.app[:settings] }
-
-  before do
-    allow(settings).to receive_messages screens_root: temp_dir, api_uri: "https://localhost"
-  end
+  include_context "with main application"
 
   describe "#call" do
     before do

--- a/spec/app/repositories/device_spec.rb
+++ b/spec/app/repositories/device_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Terminus::Repositories::Device, :db do
     it "answers nil for unknown ID" do
       expect(repository.find_by_api_key(13)).to be(nil)
     end
+
+    it "answers nil for nil" do
+      expect(repository.find_by_api_key(nil)).to be(nil)
+    end
   end
 
   describe "#find_by_mac_address" do
@@ -49,6 +53,10 @@ RSpec.describe Terminus::Repositories::Device, :db do
 
     it "answers nil for unknown ID" do
       expect(repository.find_by_mac_address(13)).to be(nil)
+    end
+
+    it "answers nil for nil" do
+      expect(repository.find_by_mac_address(nil)).to be(nil)
     end
   end
 

--- a/spec/app/views/parts/device_spec.rb
+++ b/spec/app/views/parts/device_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Terminus::Views::Parts::Device, :db do
 
   subject(:part) { described_class.new settings:, value: device, rendering: view.new.rendering }
 
-  let(:settings) { Hanami.app[:settings] }
+  include_context "with main application"
+
   let(:device) { Factory[:device] }
 
   let :view do
@@ -17,12 +18,8 @@ RSpec.describe Terminus::Views::Parts::Device, :db do
     end
   end
 
-  include_context "with temporary directory"
-
   describe "#image_uri" do
     before do
-      allow(settings).to receive(:screens_root).and_return(temp_dir)
-
       SPEC_ROOT.join("support/fixtures/test.bmp")
                .copy temp_dir.join(device.slug, "test.bmp").make_ancestors
     end

--- a/spec/hanami_helper.rb
+++ b/spec/hanami_helper.rb
@@ -34,7 +34,7 @@ RSpec.configure do |config|
   config.include Dry::Monads[:result]
   config.include Rack::Test::Methods, type: :request
 
-  config.include_context "with Hanami application", type: :request
+  config.include_context "with main application", type: :request
 
   databases = proc do
     Hanami.app.slices.with_nested.prepend(Hanami.app).each.with_object Set.new do |slice, dbs|

--- a/spec/support/shared_contexts/application.rb
+++ b/spec/support/shared_contexts/application.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_context "with Hanami application" do
-  let(:app) { Hanami.app }
-end

--- a/spec/support/shared_contexts/main_application.rb
+++ b/spec/support/shared_contexts/main_application.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with main application" do
+  include_context "with temporary directory"
+
+  let(:app) { Hanami.app }
+  let(:settings) { app[:settings] }
+
+  before do
+    allow(settings).to receive_messages(
+      api_uri: "https://localhost",
+      firmware_root: temp_dir,
+      screens_root: temp_dir
+    )
+  end
+end


### PR DESCRIPTION
## Overview

This introduces the `/api/screens` endpoint for creating custom device screens (originally known as `/api/images`). This also ensures new screens are created for specific devices based on API key.

## Details

- This completes multiple device support as all APIs are fully supported now.
- See commits for details.