### PR TITLE
Fix Dockerfile build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 RUN <<STEPS
   apt-get update -qq \
-  && apt-get install --no-install-recommends -y curl libjemalloc2 \
+  && apt-get install --no-install-recommends -y curl libjemalloc2 postgresql-client \
   && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 STEPS
 
@@ -43,12 +43,12 @@ RUN <<STEPS
 STEPS
 
 COPY . .
+RUN bundle exec hanami assets compile
 FROM base
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /app /app
 
 RUN <<STEPS
-  bundle exec hanami assets compile
   mkdir -p /app/log
   mkdir -p /app/tmp
 STEPS
@@ -61,6 +61,6 @@ USER 1000:1000
 
 ENTRYPOINT ["/app/bin/docker/entrypoint"]
 
-EXPOSE 80
+EXPOSE 2300
 
-CMD ["bundle", "exec", "hanami", "server", "--host", "0.0.0.0", "--port", "80"]
+CMD ["bundle", "exec", "puma", "--config", "./config/puma.rb"]

--- a/bin/docker/entrypoint
+++ b/bin/docker/entrypoint
@@ -6,4 +6,6 @@ $VERBOSE = true
 path = Dir["/usr/lib/*/libjemalloc.so.2"]
 ENV["LD_PRELOAD"] = path.first unless ENV.key?("LD_PRELOAD") && path.empty?
 
+system "bundle exec hanami db prepare"
+
 system ARGV.join(" ")


### PR DESCRIPTION
## Overview
The current Dockerfile doesn't build correctly:
* postgres-client is required to run the app, but isn't in the final build step
* the assets fail to compile because the build step doesn't have node installed
* the run command doesn't match the documentation
* database needs to be setup to run the app, and that isn't part of the Dockerfile

## Screenshots/Screencasts

## Details
* moved postgres-client to the `base` build step step
* moved asset compilation into the `build` build step
* changed the run command to use port 2300 as is in the documenation, and run the puma command as in documenation
* added db prepare to entrypoint to run before start to setup the database