### PR TITLE
Added screen editor (and preview)

### DIFF
--- a/app/actions/editor/create.rb
+++ b/app/actions/editor/create.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Actions
+    module Editor
+      # The create action.
+      class Create < Terminus::Action
+        include Deps[:settings, show_view: "views.editor.show"]
+        include Initable[creator: proc { Terminus::Screens::Creator.new }]
+
+        params do
+          required(:template).hash do
+            required(:id).filled :integer
+            required(:content).filled :string
+          end
+        end
+
+        def handle request, response
+          parameters = request.params
+
+          halt 422 unless parameters.valid?
+
+          if request.env.key? "HTTP_HX_REQUEST"
+            render_text parameters[:template], response
+          else
+            response.render show_view, id: Time.new.to_i
+          end
+        end
+
+        private
+
+        def render_text template, response
+          id, content = template.values_at :id, :content
+
+          creator.call content, settings.previews_root.mkpath.join("#{id}.bmp")
+
+          response.body = content.strip
+          response.status = 201
+        end
+      end
+    end
+  end
+end

--- a/app/actions/editor/show.rb
+++ b/app/actions/editor/show.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Actions
+    module Editor
+      # The show action.
+      class Show < Terminus::Action
+        def handle _request, response
+          response.render view, id: Time.new.to_i
+        end
+      end
+    end
+  end
+end

--- a/app/aspects/screens/editor/event_stream.rb
+++ b/app/aspects/screens/editor/event_stream.rb
@@ -1,0 +1,50 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "mini_magick"
+
+module Terminus
+  module Aspects
+    module Screens
+      module Editor
+        # Renders device preview image event streams.
+        class EventStream
+          include Deps[:settings]
+          include Initable[%i[req id], type: :bmp, imager: MiniMagick::Image, kernel: Kernel]
+
+          def each
+            kernel.loop do
+              yield <<~CONTENT
+                event: preview
+                data: #{image_for "/assets/previews/#{id}.#{type}", image_path}
+
+              CONTENT
+
+              kernel.sleep 1
+            end
+          ensure
+            image_path.delete if image_path.exist?
+          end
+
+          private
+
+          def image_path = settings.previews_root.join "#{id}.#{type}"
+
+          def image_for uri, path
+            return rendered_image uri, path if path.exist?
+
+            %(<img src="/assets/screen_preview.svg" alt="Loader" class="image" ) +
+              %(width="800" height="480"/>)
+          end
+
+          def rendered_image uri, path
+            width, height = imager.open(path).dimensions
+
+            %(<img src="#{uri}?#{path.mtime.to_i}" alt="Preview" class="image" ) +
+              %(width="#{width}" height="#{height}"/>)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/aspects/screens/editor/middleware.rb
+++ b/app/aspects/screens/editor/middleware.rb
@@ -1,0 +1,38 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "initable"
+
+require_relative "event_stream"
+
+module Terminus
+  module Aspects
+    module Screens
+      module Editor
+        # Streams Server Side Events (SSE) for device screen previews.
+        class Middleware
+          include Initable[
+            %i[req application],
+            %i[keyreq pattern],
+            headers: {
+              "Content-Type" => "text/event-stream",
+              "Cache-Control" => "no-cache",
+              "Connection" => "keep-alive"
+            },
+            event_stream: EventStream
+          ]
+
+          def call environment
+            request = Rack::Request.new environment
+            path = request.path
+
+            case path.match pattern
+              in id: then [200, headers, event_stream.new(id)]
+              else application.call environment
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -113,14 +113,11 @@
 }
 
 .site-figure {
+  border-radius: 0.5rem;
+  border: 1rem solid var(--site-black);
   display: flex;
   justify-content: center;
   margin: 0;
-
-  .image {
-    border-radius: 0.5rem;
-    border: 1rem solid var(--site-black);
-  }
 }
 
 .site-secret {
@@ -204,6 +201,7 @@
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+  margin: 0 1rem;
 }
 
 .page-actions {

--- a/app/assets/css/editor.css
+++ b/app/assets/css/editor.css
@@ -1,0 +1,29 @@
+.page-editor {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+
+  .terminal {
+    box-shadow:
+      0.7px 0.7px 0.7px rgba(0, 0, 0, 0.022),
+      1.7px 1.7px 1.7px rgba(0, 0, 0, 0.031),
+      3.5px 3.5px 3.5px rgba(0, 0, 0, 0.039),
+      7.3px 7.3px 7.3px rgba(0, 0, 0, 0.048),
+      20px 20px 20px rgba(0, 0, 0, 0.07)
+    ;
+    border-width: 2rem 2rem 4rem 2rem;
+  }
+
+  .form {
+    width: 100%;
+  }
+
+  .source {
+    box-sizing: border-box;
+    height: 40vh;
+    padding: 1rem;
+    width: 100%;
+    font-size: 1rem;
+    font-family: monospace;
+  }
+}

--- a/app/assets/images/screen_preview.svg
+++ b/app/assets/images/screen_preview.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 800 480" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+
+  <g transform="translate(320, 150)">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M43.2327 11.3438L85.6173 27.238L77.7464 48.227L35.3618 32.3328L43.2327 11.3438Z" fill="black"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M111.192 6.15371L125.192 49.2012L103.875 56.1339L89.8749 13.0865L111.192 6.15371Z" fill="black"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M157.609 56.0681L132.681 93.8532L113.97 81.5091L138.897 43.724L157.609 56.0681Z" fill="black"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M147.532 123.466L102.448 127.536L100.433 105.21L145.516 101.14L147.532 123.466Z" fill="black"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M88.5479 157.612L57.2569 124.902L73.4552 109.407L104.746 142.117L88.5479 157.612Z" fill="black"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M25.0725 132.803L31.1368 87.9443L53.351 90.9474L47.2868 135.806L25.0725 132.803Z" fill="black"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M4.90754 67.6822L43.7605 44.4545L55.263 63.6947L16.41 86.9224L4.90754 67.6822Z" fill="black"/>
+  </g>
+
+  <text x="405" y="350" dominant-baseline="middle" text-anchor="middle" fill="black" font-size="24" font-family="Verdana">Loading...</text>
+</svg>

--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -6,3 +6,4 @@ import "../css/layout.css";
 import "../css/components.css";
 import "../css/dashboard.css";
 import "../css/devices.css";
+import "../css/editor.css";

--- a/app/templates/editor/_default_content.html.erb
+++ b/app/templates/editor/_default_content.html.erb
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+    <meta charset="utf-8">
+
+    <style type="text/css">
+      * {
+        margin: 0;
+      }
+
+      html {
+        font-family: Verdana;
+      }
+
+      body {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Welcome to the Terminus editor!</h1>
+  </body>
+</html>

--- a/app/templates/editor/show.html.erb
+++ b/app/templates/editor/show.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, "Editor | Terminus" %>
+
+<section class="page-devices">
+  <header class="page-header">
+    <h1 class="label">Editor</h1>
+  </header>
+
+  <div class="page-body page-editor">
+    <figure class="site-figure terminal"
+            hx-ext="sse"
+            sse-connect="/preview/<%= id %>"
+            sse-swap="preview">
+    </figure>
+
+    <p>Use the text area below to design custom screens for your device using pure HTML/CSS. Changes are applied automatically as you make edits. Enjoy!</p>
+
+    <form action="/editor" method="post" class="form">
+      <%= tag.input name: "template[id]", type: :hidden, value: id %>
+      <textarea name="template[content]"
+                class="source"
+                hx-post="/editor"
+                hx-trigger="load, keyup delay:200ms"
+                hx-swap="textContent">
+        <%= render :default_content %>
+      </textarea>
+    </form>
+  </div>
+</section>

--- a/app/templates/layouts/app.html.erb
+++ b/app/templates/layouts/app.html.erb
@@ -40,6 +40,11 @@
             crossorigin="anonymous">
     </script>
 
+    <script src="https://unpkg.com/htmx-ext-sse@2.2.3"
+            integrity="sha384-Y4gc0CK6Kg+hmulDc6rZPJu0tqvk7EWlih0Oh+2OkAi1ZDlCbBDCQEE2uVk472Ky"
+            crossorigin="anonymous">
+    </script>
+
     <script src="https://unpkg.com/htmx-remove@2.0.0/build/htmx-remove.js"
             integrity="sha384-v6VOSW2F42qo+95FGFDZCY72+0md5SolbibTa8Kgn8DkCrevZNkgTsWXdEMXyeRX"
             crossorigin="anonymous">

--- a/app/templates/shared/_header.html.erb
+++ b/app/templates/shared/_header.html.erb
@@ -10,5 +10,6 @@
 
   <ul class="list">
     <li><a href="/devices" class="link">Devices</a></li>
+    <li><a href="/editor" class="link">Editor</a></li>
   </ul>
 </nav>

--- a/app/views/editor/show.rb
+++ b/app/views/editor/show.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Views
+    module Editor
+      # The show view.
+      class Show < Terminus::View
+        expose :id
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ module Terminus
     get "/devices/:device_id/logs", to: "devices.logs.index", as: :devices_logs
     get "/devices/:device_id/logs/:id", to: "devices.logs.show", as: :device_log_show
 
+    get "/editor", to: "editor.show", as: :editor
+
     slice(:health, at: "/up") { root to: "show" }
 
     use Rack::Static, root: "public", urls: ["/.well-known/security.txt"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ module Terminus
     get "/devices/:device_id/logs/:id", to: "devices.logs.show", as: :device_log_show
 
     get "/editor", to: "editor.show", as: :editor
+    post "/editor", to: "editor.create", as: :editor_create
 
     slice(:health, at: "/up") { root to: "show" }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../app/aspects/screens/editor/middleware"
+
 module Terminus
   # The application base routes.
   class Routes < Hanami::Routes
@@ -24,5 +26,6 @@ module Terminus
     slice(:health, at: "/up") { root to: "show" }
 
     use Rack::Static, root: "public", urls: ["/.well-known/security.txt"]
+    use Aspects::Screens::Editor::Middleware, pattern: %r(/preview/(?<id>\d+))
   end
 end

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -10,12 +10,16 @@ module Terminus
             constructor: Types::Params::String,
             default: "http://#{IPFinder.new.wired}:2300"
 
-    setting :screens_root,
-            constructor: Terminus::Types::Pathname,
-            default: Hanami.app.root.join("public/assets/screens")
-
     setting :firmware_root,
             constructor: Terminus::Types::Pathname,
             default: Hanami.app.root.join("public/assets/firmware")
+
+    setting :previews_root,
+            constructor: Terminus::Types::Pathname,
+            default: Hanami.app.root.join("public/assets/previews")
+
+    setting :screens_root,
+            constructor: Terminus::Types::Pathname,
+            default: Hanami.app.root.join("public/assets/screens")
   end
 end

--- a/spec/app/actions/editor/create_spec.rb
+++ b/spec/app/actions/editor/create_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Actions::Editor::Create do
+  subject(:action) { described_class.new }
+
+  include_context "with main application"
+
+  describe "#call" do
+    let(:device) { Factory[:device] }
+    let(:parameters) { {template: {id: 123, content: "<p>Test</p>"}} }
+
+    it "answers original content" do
+      response = Rack::MockRequest.new(action).post "",
+                                                    "HTTP_HX_REQUEST" => true,
+                                                    params: parameters
+      expect(response.body).to eq("<p>Test</p>")
+    end
+
+    it "creates preview image" do
+      Rack::MockRequest.new(action).post "", "HTTP_HX_REQUEST" => true, params: parameters
+      expect(temp_dir.join("123.bmp").exist?).to be(true)
+    end
+
+    it "answers created status" do
+      response = Rack::MockRequest.new(action).post "",
+                                                    "HTTP_HX_REQUEST" => true,
+                                                    params: parameters
+
+      expect(response.status).to eq(201)
+    end
+
+    it "renders show view when form is submitted" do
+      response = Rack::MockRequest.new(action).post "", params: parameters
+      expect(response.body).to include("Welcome to the Terminus editor!")
+    end
+
+    it "answers unprocessable content with invalid parameters" do
+      parameters[:template].delete :id
+      response = Rack::MockRequest.new(action).post "", params: parameters
+
+      expect(response.status).to eq(422)
+    end
+  end
+end

--- a/spec/app/aspects/screens/editor/event_stream_spec.rb
+++ b/spec/app/aspects/screens/editor/event_stream_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Aspects::Screens::Editor::EventStream do
+  using Refinements::Pathname
+
+  subject(:event_stream) { described_class.new "test", type: :png, kernel: }
+
+  include_context "with main application"
+
+  let(:kernel) { class_spy Kernel }
+
+  describe "#each" do
+    let(:image_path) { temp_dir.join "test.png" }
+
+    before do
+      allow(kernel).to receive(:loop).and_yield
+      SPEC_ROOT.join("support/fixtures/test.png").copy image_path
+    end
+
+    it "answers rendered image when path matches" do
+      payload = nil
+      at = image_path.mtime.to_i
+
+      event_stream.each { payload = it }
+
+      expect(payload).to eq(<<~CONTENT)
+        event: preview
+        data: <img src="/assets/previews/test.png?#{at}" alt="Preview" class="image" width="1" height="1"/>
+
+      CONTENT
+    end
+
+    it "falls back to loading image when path doesn't exist" do
+      image_path.delete
+      payload = nil
+      event_stream.each { payload = it }
+
+      expect(payload).to eq(<<~CONTENT)
+        event: preview
+        data: <img src="/assets/screen_preview.svg" alt="Loader" class="image" width="800" height="480"/>
+
+      CONTENT
+    end
+
+    it "ensures image is always deleted" do
+      event_stream.each(&:to_s)
+      expect(image_path.exist?).to be(false)
+    end
+
+    it "sleeps for one second" do
+      event_stream.each(&:to_s)
+      expect(kernel).to have_received(:sleep).with(1)
+    end
+  end
+end

--- a/spec/app/aspects/screens/editor/middleware_spec.rb
+++ b/spec/app/aspects/screens/editor/middleware_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Aspects::Screens::Editor::Middleware do
+  subject(:middleware) { described_class.new application, pattern: %r(/preview/(?<id>\d+)) }
+
+  let(:application) { proc { [200, {}, []] } }
+
+  describe "#call" do
+    it "answers event stream when path matches" do
+      environment = Rack::MockRequest.env_for "/preview/1", method: :get
+
+      expect(middleware.call(environment)).to match(
+        array_including(
+          200,
+          {
+            "Content-Type" => "text/event-stream",
+            "Cache-Control" => "no-cache",
+            "Connection" => "keep-alive"
+          },
+          instance_of(Terminus::Aspects::Screens::Editor::EventStream)
+        )
+      )
+    end
+
+    it "passes ID to event stream" do
+      event_stream = class_spy Terminus::Aspects::Screens::Editor::EventStream
+      middleware = described_class.new(application, pattern: %r(/preview/(?<id>\d+)), event_stream:)
+      environment = Rack::MockRequest.env_for "/preview/123", method: :get
+      middleware.call environment
+
+      expect(event_stream).to have_received(:new).with("123")
+    end
+
+    it "answers original response when path doesn't match" do
+      environment = Rack::MockRequest.env_for "/bogus", method: :get
+      expect(middleware.call(environment)).to eq([200, {}, []])
+    end
+
+    it "answers original response when verb doesn't match" do
+      environment = Rack::MockRequest.env_for "/test/1/example", method: :put
+      expect(middleware.call(environment)).to eq([200, {}, []])
+    end
+  end
+end

--- a/spec/features/editor_spec.rb
+++ b/spec/features/editor_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe "Editor" do
+  it "renders page" do
+    visit routes.path(:editor)
+    expect(page).to have_content("Welcome to the Terminus editor!")
+  end
+end

--- a/spec/support/shared_contexts/main_application.rb
+++ b/spec/support/shared_contexts/main_application.rb
@@ -12,6 +12,7 @@ RSpec.shared_context "with main application" do
     allow(settings).to receive_messages(
       api_uri: "https://localhost",
       firmware_root: temp_dir,
+      previews_root: temp_dir,
       screens_root: temp_dir
     )
   end


### PR DESCRIPTION
## Overview

Provides the ability dynamically build new screens using HTML and CSS by using Server Sent Events (SSE). This speeds up custom image generation and exploring new ideas while being able to use the resulting template to create new images for your device (either from the console or the API).

## Screenshots/Screencasts

https://github.com/user-attachments/assets/f48daf83-c647-4fb2-b99d-63da806222c1

## Details

- Resolves Issue #5.
- See commits for details.