### PR TITLE
README: Fix compose env vars

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -527,9 +527,9 @@ bin/rake
 
 link:https://docs.docker.com/compose[Docker Compose] support is provided so you can quickly spin up the images and containers for running this application either in development or production. Full details are captured in the `compose.yml` at the root of this project. The `compose.yml` can also be configured via the following environment variables:
 
-* `POSTGRES_USER`: Your PostgreSQL user name.
-* `POSTGRES_DB`: Your PostgreSQL database name.
-* `POSTGRES_PASSWORD`: Your PostgreSQL password.
+* `PG_USER`: Your PostgreSQL user name.
+* `PG_DATABASE`: Your PostgreSQL database name.
+* `PG_PASSWORD`: Your PostgreSQL password.
 
 💡 The above is automatically generated for you when running `bin/setup` with safe default values but customization is definitely encouraged.
 


### PR DESCRIPTION
## Overview
Fixes #70
PR #71 introduced more documentation for docker-compose, however the documented environment variables have the wrong name. This uses the correct environment variable names `PG_*` instead of `POSTGRES_*`

## Details
<!-- Optional. List the key features/highlights as bullet points. -->
I noticed when naively running `docker-compose up` without setting any env-vars, I get the following output:

```shell
docker-compose up   
WARNING: The PG_USER variable is not set. Defaulting to a blank string.
WARNING: The PG_PASSWORD variable is not set. Defaulting to a blank string.
WARNING: The PG_DATABASE variable is not set. Defaulting to a blank string.
```


Looking at the `compose.yaml`, I believe the env-vars are called `PG_*` and not `POSTGRES_*`
https://github.com/usetrmnl/byos_hanami/blob/fca3ce6a64cb6f37298f7185d5bde95c4094c3b5/compose.yaml#L27