### PR TITLE
Fix typo in API request JSON

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -286,7 +286,7 @@ curl -X "POST" "https://localhost:2443/api/screens" \
     -H 'Content-Type: application/json' \
     -d $'{
  "image": {
-   "content": "<p>Test</p>"
+   "content": "<p>Test</p>",
    "file_name": "test"
  }
 }'


### PR DESCRIPTION
## Overview
Fix missing comma in JSON from README in section on /api/screens Request docs
