### PR TITLE
Updated device and device log searching to retain queries

### DIFF
--- a/app/actions/devices/index.rb
+++ b/app/actions/devices/index.rb
@@ -7,23 +7,26 @@ module Terminus
       class Index < Terminus::Action
         include Deps[repository: "repositories.device"]
 
-        params { optional(:query).filled :string }
-
         def handle request, response
-          query = request.params[:query]
+          query = request.params[:query].to_s
+          devices = load_devices query
 
           if request.get_header("HTTP_HX_TRIGGER") == "search"
             add_htmx_headers response, query
-            response.render view, devices: repository.find_all_by_label(query), layout: false
+            response.render view, devices:, query:, layout: false
           else
-            response.render view, devices: repository.all
+            response.render view, devices:, query:
           end
         end
 
         private
 
+        def load_devices query
+          query.empty? ? repository.all : repository.find_all_by_label(query)
+        end
+
         def add_htmx_headers response, query
-          return unless query
+          return if query.empty?
 
           response.headers["HX-Push-Url"] = routes.path :devices, query:
         end

--- a/app/actions/devices/index.rb
+++ b/app/actions/devices/index.rb
@@ -22,7 +22,7 @@ module Terminus
         private
 
         def load_devices query
-          query.empty? ? repository.all : repository.find_all_by_label(query)
+          query.empty? ? repository.all : repository.all_by_label(query)
         end
 
         def add_htmx_headers response, query

--- a/app/actions/devices/logs/index.rb
+++ b/app/actions/devices/logs/index.rb
@@ -13,28 +13,39 @@ module Terminus
 
           params do
             required(:device_id).filled :integer
-            optional(:query).filled :string
+            optional(:query).maybe :string
           end
 
           # :reek:TooManyStatements
+          # rubocop:todo Metrics/MethodLength
           def handle request, response
             parameters = request.params
-            query = parameters[:query]
+
+            halt :unprocessable_entity unless parameters.valid?
+
+            query = parameters[:query].to_s
             device = device_repository.find parameters[:device_id]
-            logs = repository.all_by_message device.id, query
+            logs = load_logs device.id, query
 
             if request.get_header("HTTP_HX_TRIGGER") == "search"
               add_htmx_headers response, device, query
-              response.render view, device:, logs:, layout: false
+              response.render view, device:, logs:, query:, layout: false
             else
-              response.render view, device:, logs:
+              response.render view, device:, logs:, query:
             end
           end
+          # rubocop:enable Metrics/MethodLength
 
           private
 
+          def load_logs device_id, query
+            return repository.all_by_device device_id if query.empty?
+
+            repository.all_by_message device_id, query
+          end
+
           def add_htmx_headers response, device, query
-            return unless query
+            return if query.empty?
 
             response.headers["HX-Push-Url"] = routes.path :device_logs, device_id: device.id, query:
           end

--- a/app/assets/css/components.css
+++ b/app/assets/css/components.css
@@ -1,29 +1,11 @@
-.button {
-  padding: 0.5rem 1rem;
-  border-radius: 1.5rem;
-}
-
-.button-new {
-  background-color: var(--site-orange);
-  color: white;
-  text-decoration: none;
-
-  &:hover {
-    background-color: var(--site-white);
-    color: var(--site-orange);
-  }
-}
-
 .button-accept, .button-decline {
-  border: none;
-  padding: 0.5rem 1rem;
   border-radius: 1.5rem;
+  border: none;
   cursor: pointer;
   font-size: 1rem;
-  text-decoration: none;
-  margin-top: 1rem;
   margin-bottom: 1rem;
-  box-shadow: 0 6px 12px 0 rgba(0,0,0,0.1), 0 4px 12px 0 rgba(0,0,0,0.1);
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
 }
 
 .button-accept {
@@ -32,6 +14,7 @@
 
   &:hover {
     background-color: var(--site-darkorange);
+    text-decoration: none;
   }
 }
 
@@ -40,7 +23,7 @@
   color: var(--site-black);
 
   &:hover {
-    background-color: oklch(from var(--site-white) l c h / 0.2);
+    background-color: oklch(from var(--site-lightgrey) l c h / 0.2);
     text-decoration: none;
   }
 }
@@ -349,36 +332,6 @@
     display: flex;
     align-items: center;
     gap: 1rem;
-  }
-
-  .accept, .decline {
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 1.5rem;
-    cursor: pointer;
-    font-size: 1rem;
-    text-decoration: none;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-    box-shadow: 0 6px 12px 0 rgba(0,0,0,0.1), 0 4px 12px 0 rgba(0,0,0,0.1);
-  }
-
-  .accept {
-    background: var(--site-orange);
-    color: var(--site-white);
-
-    &:hover {
-      background-color: var(--site-darkorange);
-    }
-  }
-
-  .decline {
-    background: var(--site-white);
-    color: var(--site-black);
-
-    &:hover {
-      background-color: oklch(from var(--site-white) l c h / 0.2);
-    }
   }
 
   .error {

--- a/app/repositories/device.rb
+++ b/app/repositories/device.rb
@@ -11,13 +11,13 @@ module Terminus
                .to_a
       end
 
-      def find(id) = (devices.by_pk(id).one if id)
-
-      def find_all_by_label value
+      def all_by_label value
         devices.where { label.ilike "%#{value}%" }
                .order { created_at.asc }
                .to_a
       end
+
+      def find(id) = (devices.by_pk(id).one if id)
 
       def find_by_api_key value
         return unless value

--- a/app/repositories/device_log.rb
+++ b/app/repositories/device_log.rb
@@ -12,8 +12,8 @@ module Terminus
                    .to_a
       end
 
-      def all_by_device device_id
-        device_logs.where(device_id:)
+      def all_by_device id
+        device_logs.where(device_id: id)
                    .order { created_at.desc }
                    .to_a
       end
@@ -27,7 +27,7 @@ module Terminus
 
       def find(id) = (device_logs.combine(:device).by_pk(id).one if id)
 
-      def delete_by_device(device_id, id) = device_logs.where(device_id: device_id, id: id).delete
+      def delete_by_device(device_id, id) = device_logs.where(device_id:, id:).delete
     end
   end
 end

--- a/app/templates/devices/_cancel_link.html.erb
+++ b/app/templates/devices/_cancel_link.html.erb
@@ -1,1 +1,0 @@
-<%= link_to "Cancel", routes.path(:devices), class: :decline %>

--- a/app/templates/devices/_save_button.html.erb
+++ b/app/templates/devices/_save_button.html.erb
@@ -1,6 +1,6 @@
 <input type="submit"
        value="Save"
-       class="accept"
+       class="button-accept"
        <%= "hx-#{verb}=#{path}" %>
        hx-trigger="click, keyup[ctrlKey&&key=='s'] from:closest .device"
        hx-target="closest .page-devices"

--- a/app/templates/devices/_search.html.erb
+++ b/app/templates/devices/_search.html.erb
@@ -2,7 +2,7 @@
   <%= tag.form(action: routes.path(:devices), method: :get, class: "page-search") do %>
     <input id="search"
            name="query"
-           value=""
+           value="<%= query %>"
            class="value"
            hx-get="<%= routes.path :devices %>"
            hx-trigger="search, keyup delay:200ms changed"

--- a/app/templates/devices/edit.html.erb
+++ b/app/templates/devices/edit.html.erb
@@ -18,7 +18,16 @@
 
       <div class="form-actions">
         <%= render "save_button", verb: :put, path: "/devices/#{device.id}" %>
-        <%= render "cancel_link" %>
+
+        <a href="<%= routes.path :device_show, id: device.id %>"
+           class="decline"
+           hx-get="<%= routes.path :device_show, id: device.id %>"
+           hx-trigger="click"
+           hx-target="closest .page-devices"
+           hx-swap="outerHTML"
+           hx-push-url="true">
+           Cancel
+        </a>
       </div>
     </form>
   </div>

--- a/app/templates/devices/edit.html.erb
+++ b/app/templates/devices/edit.html.erb
@@ -20,7 +20,7 @@
         <%= render "save_button", verb: :put, path: "/devices/#{device.id}" %>
 
         <a href="<%= routes.path :device_show, id: device.id %>"
-           class="decline"
+           class="button-decline"
            hx-get="<%= routes.path :device_show, id: device.id %>"
            hx-trigger="click"
            hx-target="closest .page-devices"

--- a/app/templates/devices/index.html.erb
+++ b/app/templates/devices/index.html.erb
@@ -30,7 +30,7 @@
     </dialog>
 
     <div class="actions">
-      <%= render :search %>
+      <%= render :search, query: %>
 
       <a href="/devices/new"
          class="button button-new"
@@ -51,9 +51,8 @@
       <% end %>
     </ul>
   <% else %>
-    <div class="page-empty">
-      <span class="icon">🌌</span>
-      <p class="message">No devices found.</p>
+    <div class="devices">
+      <%= render "shared/empty", message: "No devices found." %>
     </div>
   <% end %>
 </section>

--- a/app/templates/devices/index.html.erb
+++ b/app/templates/devices/index.html.erb
@@ -33,7 +33,7 @@
       <%= render :search, query: %>
 
       <a href="/devices/new"
-         class="button button-new"
+         class="button-accept"
          hx-get="/devices/new"
          hx-trigger="click, keyup[ctrlKey&&key=='n'] from:body"
          hx-target="closest .page-devices"

--- a/app/templates/devices/logs/_search.html.erb
+++ b/app/templates/devices/logs/_search.html.erb
@@ -1,14 +1,13 @@
 <search>
   <%= tag.form(action: routes.path(:device_logs, device_id: device.id), method: :get, class: "page-search") do %>
     <input id="search"
-           type="search"
            name="query"
-           value=""
+           value="<%= query %>"
            class="value"
            hx-get="<%= routes.path :device_logs, device_id: device.id %>"
            hx-trigger="search, keyup delay:200ms changed"
-           hx-select=".logs"
-           hx-target="next .logs"
+           hx-select=".site-container"
+           hx-target="next .site-container"
            hx-swap="outerHTML"
            hx-push-url="true"
            hx-indicator=".page-loader"/>

--- a/app/templates/devices/logs/index.html.erb
+++ b/app/templates/devices/logs/index.html.erb
@@ -8,11 +8,11 @@
       <li class="breadcrumb">Logs</li>
     </ul>
 
-    <%= render :search, device: %>
+    <%= render :search, device:, query: %>
   </header>
 
-  <% if logs.any? %>
-    <div class="site-container">
+  <div class="site-container">
+    <% if logs.any? %>
       <table class="site-table">
         <thead>
           <tr>
@@ -25,17 +25,14 @@
           </tr>
         </thead>
 
-        <tbody class="logs">
+        <tbody>
           <% logs.each do |log| %>
             <%= log.render :log, device: %>
           <% end %>
         </tbody>
       </table>
-    </div>
-  <% else %>
-    <div class="page-empty">
-      <span class="icon">🌌</span>
-      <p class="message">All is quiet.</p>
-    </div>
-  <% end %>
+    <% else %>
+      <%= render "shared/empty", message: "No logs found." %>
+    <% end %>
+  </div>
 </section>

--- a/app/templates/devices/new.html.erb
+++ b/app/templates/devices/new.html.erb
@@ -18,7 +18,7 @@
 
       <div class="form-actions">
         <%= render "save_button", verb: :post, path: "/devices" %>
-        <%= render "cancel_link" %>
+        <%= link_to "Cancel", routes.path(:devices), class: :decline %>
       </div>
     </form>
   </div>

--- a/app/templates/devices/new.html.erb
+++ b/app/templates/devices/new.html.erb
@@ -18,7 +18,7 @@
 
       <div class="form-actions">
         <%= render "save_button", verb: :post, path: "/devices" %>
-        <%= link_to "Cancel", routes.path(:devices), class: :decline %>
+        <%= link_to "Cancel", routes.path(:devices), class: "button-decline" %>
       </div>
     </form>
   </div>

--- a/app/templates/shared/_empty.html.erb
+++ b/app/templates/shared/_empty.html.erb
@@ -1,0 +1,4 @@
+<div class="page-empty">
+  <span class="icon">🌌</span>
+  <%= tag.p message, class: :message %>
+</div>

--- a/app/views/devices/index.rb
+++ b/app/views/devices/index.rb
@@ -6,6 +6,7 @@ module Terminus
       # The index view.
       class Index < Terminus::View
         expose :devices
+        expose :query
       end
     end
   end

--- a/app/views/devices/logs/index.rb
+++ b/app/views/devices/logs/index.rb
@@ -8,6 +8,7 @@ module Terminus
         class Index < Terminus::View
           expose :device
           expose :logs
+          expose :query
         end
       end
     end

--- a/spec/app/actions/devices/logs/index_spec.rb
+++ b/spec/app/actions/devices/logs/index_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Terminus::Actions::Devices::Logs::Index, :db do
   describe "#call" do
     let(:device_log) { Factory[:device_log] }
 
+    it "answers unprocessable entity status when required parameters are missing" do
+      response = Rack::MockRequest.new(action).get ""
+
+      expect(response.status).to eq(422)
+    end
+
     it "renders standard response with search results" do
       response = Rack::MockRequest.new(action).get "", params: {device_id: device_log.device_id}
 
@@ -21,7 +27,7 @@ RSpec.describe Terminus::Actions::Devices::Logs::Index, :db do
                                                      query: "bogus"
                                                    }
 
-      expect(response.body).to include("All is quiet")
+      expect(response.body).to include("No logs found.")
     end
 
     it "renders htmx response with search results" do
@@ -40,7 +46,7 @@ RSpec.describe Terminus::Actions::Devices::Logs::Index, :db do
                                                      query: "bogus"
                                                    }
 
-      expect(response.body).to include("All is quiet")
+      expect(response.body).to include("No logs found.")
     end
   end
 end

--- a/spec/app/repositories/device_spec.rb
+++ b/spec/app/repositories/device_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe Terminus::Repositories::Device, :db do
     end
   end
 
-  describe "#find_all_by_label" do
+  describe "#all_by_label" do
     it "answers record for label" do
-      expect(repository.find_all_by_label(device.label)).to contain_exactly(device)
+      expect(repository.all_by_label(device.label)).to contain_exactly(device)
     end
 
     it "empty array for unknown label" do
-      expect(repository.find_all_by_label("bogus")).to eq([])
+      expect(repository.all_by_label("bogus")).to eq([])
     end
   end
 


### PR DESCRIPTION
## Overview

This makes searching more robust by remembering what your query was and showing it in the search field. Additional cleanup to reduce duplication in partials and stylesheets.

## Details

- See commits for details.