### PR TITLE
Fixed infinite firmware update loops

### DIFF
--- a/app/actions/api/display/show.rb
+++ b/app/actions/api/display/show.rb
@@ -48,18 +48,18 @@ module Terminus
             image_fetcher.call mac_address.tr(":", Dry::Core::EMPTY_STRING), encryption:
           end
 
-          def fetch_firmware
-            firmware_fetcher.call
-                            .relative_path_from(config.public_directory)
-                            .then { |relative_path| "#{settings.api_uri}/#{relative_path}" }
-          end
-
           def build_record image, device
             model[
-              firmware_url: fetch_firmware,
+              firmware_url: fetch_firmware_uri(device),
               **image.slice(:image_url, :filename),
               **device.as_api_display
             ]
+          end
+
+          def fetch_firmware_uri device
+            firmware_fetcher.call.first.then do
+              it.uri if device.firmware_version != it.version
+            end
           end
         end
       end

--- a/app/actions/dashboard/show.rb
+++ b/app/actions/dashboard/show.rb
@@ -19,13 +19,9 @@ module Terminus
           response.render view,
                           api_uri: settings.api_uri,
                           devices: device_repository.all,
-                          firmware_path:,
+                          firmwares: firmware_fetcher.call,
                           ip_addresses: ip_finder.all
         end
-
-        private
-
-        def firmware_path = firmware_fetcher.call.relative_path_from config.public_directory
       end
     end
   end

--- a/app/aspects/firmware/downloader.rb
+++ b/app/aspects/firmware/downloader.rb
@@ -20,7 +20,7 @@ module Terminus
 
           case result
             in Success(payload)
-              return Success(path(payload)) if fetcher.call.name.to_s == payload.version
+              return Success(path(payload)) if latest_firmware_version == payload.version
 
               save payload
             else result
@@ -28,6 +28,10 @@ module Terminus
         end
 
         private
+
+        def path(payload) = settings.firmware_root.join "#{payload.version}.bin"
+
+        def latest_firmware_version = fetcher.call.first.then { it.version if it }
 
         def save payload
           get(payload.url).fmap { |content| path(payload).make_ancestors.write(content) }
@@ -42,8 +46,6 @@ module Terminus
         rescue OpenSSL::SSL::SSLError => error
           Failure error.message
         end
-
-        def path(payload) = settings.firmware_root.join "#{payload.version}.bin"
       end
     end
   end

--- a/app/aspects/firmware/fetcher.rb
+++ b/app/aspects/firmware/fetcher.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "initable"
 require "refinements/pathname"
 
 module Terminus
@@ -8,10 +9,23 @@ module Terminus
       # Fetches latest firmware download.
       class Fetcher
         include Deps[:settings]
+        include Initable[public_root: proc { Hanami.app.root.join("public") }, model: Model]
 
         using Refinements::Pathname
 
-        def call = settings.firmware_root.then { |root| root.files("*.bin").last || root }
+        def call
+          settings.firmware_root.files("*.bin").reverse.map do |path|
+            model[path: build_relative(path), uri: build_uri(path), version: path.name.to_s]
+          end
+        end
+
+        private
+
+        def build_relative(path) = path.relative_path_from public_root
+
+        def build_uri path
+          build_relative(path).then { |relative_path| "#{settings.api_uri}/#{relative_path}" }
+        end
       end
     end
   end

--- a/app/aspects/firmware/model.rb
+++ b/app/aspects/firmware/model.rb
@@ -1,0 +1,13 @@
+# auto_register: false
+# frozen_string_literal: true
+
+module Terminus
+  module Aspects
+    module Firmware
+      # Models firmware information.
+      Model = Data.define :path, :uri, :version do
+        def initialize(path: nil, uri: nil, version: nil) = super
+      end
+    end
+  end
+end

--- a/app/templates/dashboard/show.html.erb
+++ b/app/templates/dashboard/show.html.erb
@@ -71,7 +71,9 @@
       </legend>
 
       <ul class="list">
-        <li><%= link_to firmware_path.basename(".bin"), firmware_path %></li>
+        <% firmwares.each do |record| %>
+          <li><%= link_to record.version, record.path %></li>
+        <% end %>
       </ul>
 
       <dialog id="popover-firmware" class="popover-content" popover="auto">

--- a/app/templates/devices/_fields.html.erb
+++ b/app/templates/devices/_fields.html.erb
@@ -78,7 +78,7 @@
   <%= render "field_popover_content",
              name: "firmware_update",
              label: "Firmware Update",
-             body: "When enabled, allows your device to be automatically updated when a new firmware version is available. At the moment, you'll want to immediately disable this once you see your device being updated or it'll go into an infinite update loop. This due to a firmware bug." %>
+             body: "When enabled, allows your device to be automatically updated when a new firmware version is available." %>
 
   <%= scope(:form_field, key: :proxy, errors:).render do %>
     <label class="key" for="device[proxy]">

--- a/app/views/dashboard/show.rb
+++ b/app/views/dashboard/show.rb
@@ -8,7 +8,7 @@ module Terminus
         expose :api_uri
         expose :devices
         expose :ip_addresses
-        expose :firmware_path
+        expose :firmwares
       end
     end
   end

--- a/spec/app/aspects/firmware/model_spec.rb
+++ b/spec/app/aspects/firmware/model_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Aspects::Firmware::Model do
+  subject(:model) { described_class.new }
+
+  describe "#initialize" do
+    it "answers default attributes" do
+      expect(model).to have_attributes(path: nil, uri: nil, version: nil)
+    end
+  end
+end

--- a/spec/requests/display_spec.rb
+++ b/spec/requests/display_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe "/api/display", :db do
     )
   end
 
+  it "answers removes firmware URI when device and latest firmware versions match" do
+    temp_dir.join("1.2.3.bin").touch
+    get routes.path(:api_display), {}, **firmware_headers
+
+    expect(json_payload).to include(
+      filename: /.+\.bmp/,
+      firmware_url: nil,
+      image_url: %r(https://.+/assets/screens/A1B2C3D4E5F6.+\.bmp),
+      image_url_timeout: 0,
+      refresh_rate: 900,
+      reset_firmware: false,
+      special_function: "sleep",
+      update_firmware: false
+    )
+  end
+
   it "answers not found for index with invalid access token" do
     get routes.path(:api_display)
     expect(last_response.status).to eq(404)


### PR DESCRIPTION
## Overview

This is still a firmware bug but we now workaround this situation by not providing the URL when the versions match. Only when the versions don't match will the URL be provided (which prevents the infinite loop). This also means you can enable firmware updates for your device without having to manually worry about toggling it off and on.

As a nice side effect of this work, your dashboard will update to show all downloaded firmware versions so you can see the full history.

## Details

- See commits for details.