### PR TITLE
Updated to TRMNL API 0.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,7 +482,7 @@ GEM
       refinements (~> 13.0)
       zeitwerk (~> 2.7)
     transproc (1.1.1)
-    trmnl-api (0.0.0)
+    trmnl-api (0.1.0)
       cogger (~> 1.2)
       containable (~> 1.2)
       dry-monads (~> 1.8)
@@ -748,7 +748,7 @@ CHECKSUMS
   tilt (2.6.0) sha256=263d748466e0d83e510aa1a2e2281eff547937f0ef06be33d3632721e255f76b
   tone (2.3.0) sha256=89af00de299f3d952dfa7412678aea909a64effe9f8301b14e147e230ff4652a
   transproc (1.1.1) sha256=b2f9a85ecaf7064f0b3893ffac929de9fd713b13f5aaf822b0bd091fd6f5c8c2
-  trmnl-api (0.0.0) sha256=c4e4ff943f2f6ed785c4f801762967767ec3911134217eb99f93d7a5f640bb77
+  trmnl-api (0.1.0) sha256=30a54b74f390bad6997ad4691cc4c5c9581f32be33311c835b3be6ee0d45e06a
   unicode-display_width (3.1.4) sha256=8caf2af1c0f2f07ec89ef9e18c7d88c2790e217c482bfc78aaa65eadd5415ac1
   unicode-emoji (4.0.4) sha256=2c2c4ef7f353e5809497126285a50b23056cc6e61b64433764a35eff6c36532a
   versionaire (14.2.0) sha256=f52fbcbc54d6b37f63a8151de7d3f1ec8cb0d2cc5a1886723497a8686a634476

--- a/app/aspects/firmware/downloader.rb
+++ b/app/aspects/firmware/downloader.rb
@@ -11,12 +11,12 @@ module Terminus
         include Deps[:settings, fetcher: "aspects.firmware.fetcher"]
         include Dependencies[client: :downloader]
         include Dry::Monads[:result]
-        include Initable[endpoint: proc { TRMNL::API::Endpoints::Firmware.new }]
+        include Initable[api_client: proc { TRMNL::API::Client.new }]
 
         using Refinements::Pathname
 
         def call
-          result = endpoint.call
+          result = api_client.firmware
 
           case result
             in Success(payload)

--- a/app/aspects/screens/poller.rb
+++ b/app/aspects/screens/poller.rb
@@ -9,7 +9,7 @@ module Terminus
       # Polls the Core Display API on a scheduled interval for new images to display locally.
       class Poller
         include Deps["aspects.screens.downloader", repository: "repositories.device"]
-        include Initable[endpoint: proc { TRMNL::API::Endpoints::Display.new }, kernel: Kernel]
+        include Initable[client: proc { TRMNL::API::Client.new }, kernel: Kernel]
         include Dry::Monads[:result]
 
         # Seconds equates to five minutes (60 * 5).
@@ -39,7 +39,7 @@ module Terminus
         end
 
         def process device
-          endpoint.call(token: device.api_key).bind do |response|
+          client.display(token: device.api_key).bind do |response|
             downloader.call response.image_url, "#{device.slug}/#{response.filename}"
           end
         end

--- a/spec/app/aspects/firmware/downloader_spec.rb
+++ b/spec/app/aspects/firmware/downloader_spec.rb
@@ -5,16 +5,16 @@ require "hanami_helper"
 RSpec.describe Terminus::Aspects::Firmware::Downloader do
   using Refinements::Pathname
 
-  subject(:downloader) { described_class.new endpoint: }
+  subject(:downloader) { described_class.new api_client: }
 
   include_context "with main application"
   include_context "with library dependencies"
 
   let(:http) { HTTP }
 
-  let :endpoint do
-    instance_double TRMNL::API::Endpoints::Firmware,
-                    call: Success(
+  let :api_client do
+    instance_double TRMNL::API::Client,
+                    firmware: Success(
                       TRMNL::API::Models::Firmware[
                         url: "https://trmnl-fw.s3.us-east-2.amazonaws.com/FW1.5.2.bin",
                         version: "1.5.2"
@@ -34,10 +34,8 @@ RSpec.describe Terminus::Aspects::Firmware::Downloader do
       expect(downloader.call).to be_success(path)
     end
 
-    context "with endpoint failure" do
-      let :endpoint do
-        instance_double TRMNL::API::Endpoints::Firmware, call: Failure(message: "Danger!")
-      end
+    context "with API client failure" do
+      let(:api_client) { instance_double TRMNL::API::Client, firmware: Failure(message: "Danger!") }
 
       it "answers failure when image can't be downloaded" do
         expect(downloader.call).to be_failure(message: "Danger!")

--- a/spec/app/aspects/screens/poller_spec.rb
+++ b/spec/app/aspects/screens/poller_spec.rb
@@ -3,13 +3,13 @@
 require "hanami_helper"
 
 RSpec.describe Terminus::Aspects::Screens::Poller, :db do
-  subject(:poller) { described_class.new endpoint:, downloader:, kernel: }
+  subject(:poller) { described_class.new client:, downloader:, kernel: }
 
   let(:kernel) { class_spy Kernel, sleep: nil }
 
-  let :endpoint do
-    instance_spy TRMNL::API::Endpoints::Display,
-                 call: Success(
+  let :client do
+    instance_spy TRMNL::API::Client,
+                 display: Success(
                    TRMNL::API::Models::Display[
                      image_url: "https://test.io/test.bmp",
                      filename: "test.bmp"
@@ -44,7 +44,7 @@ RSpec.describe Terminus::Aspects::Screens::Poller, :db do
 
     it "requests image for device API key" do
       poller.call
-      expect(endpoint).to have_received(:call)
+      expect(client).to have_received(:display)
     end
 
     it "downloads image" do
@@ -75,9 +75,7 @@ RSpec.describe Terminus::Aspects::Screens::Poller, :db do
     end
 
     context "with remote image failure" do
-      let :endpoint do
-        instance_spy TRMNL::API::Endpoints::Display, call: Failure("Danger!")
-      end
+      let(:client) { instance_spy TRMNL::API::Client, display: Failure("Danger!") }
 
       it "doesn't download image" do
         poller.call


### PR DESCRIPTION
## Overview

Necessary to pick up latest changes and make use of the new Object API since we no longer have to use individual endpoint objects.
