### PR TITLE
Fixed multiple device communication with firmware

### DIFF
--- a/app/actions/api/display/show.rb
+++ b/app/actions/api/display/show.rb
@@ -12,8 +12,6 @@ module Terminus
         # The show action.
         class Show < Terminus::Action
           include Deps[
-            :settings,
-            repository: "repositories.device",
             image_fetcher: "aspects.screens.rotator",
             firmware_fetcher: "aspects.firmware.fetcher",
             synchronizer: "aspects.synchronizers.device"

--- a/app/aspects/screens/fetcher.rb
+++ b/app/aspects/screens/fetcher.rb
@@ -32,7 +32,7 @@ module Terminus
           end
         end
 
-        def default = {filename: "empty_state", image_url: "#{settings.api_uri}/assets/setup.svg"}
+        def default = {filename: "empty_state", image_url: "#{settings.api_uri}/assets/setup.bmp"}
       end
     end
   end

--- a/app/aspects/synchronizers/device.rb
+++ b/app/aspects/synchronizers/device.rb
@@ -20,8 +20,9 @@ module Terminus
 
         def update result
           result.bind do |payload|
-            device = repository.update_by_api_key(payload.api_key, **payload.device_attributes)
-            device ? Success(device) : Failure("Unable to find device by API key.")
+            device = repository.update_by_mac_address payload.mac_address,
+                                                      **payload.device_attributes
+            device ? Success(device) : Failure("Unable to find device by MAC address.")
           end
         end
       end

--- a/app/repositories/device.rb
+++ b/app/repositories/device.rb
@@ -19,22 +19,13 @@ module Terminus
 
       def find(id) = (devices.by_pk(id).one if id)
 
-      def find_by_api_key value
-        return unless value
+      def find_by_api_key(value) = devices.where(api_key: value.to_s).one
 
-        devices.where { api_key.ilike "%#{value}%" }
-               .one
-      end
+      def find_by_mac_address(value) = devices.where(mac_address: value.to_s).one
 
-      def find_by_mac_address value
-        return unless value
-
-        devices.where { mac_address.ilike "%#{value}%" }
-               .one
-      end
-
-      def update_by_api_key(value, **attributes)
-        relation = devices.where { api_key.ilike "%#{value}%" }
+      # :reek:FeatureEnvy
+      def update_by_mac_address(value, **attributes)
+        relation = devices.where mac_address: value.to_s
 
         return relation.one if attributes.empty?
 

--- a/spec/app/aspects/screens/fetcher_spec.rb
+++ b/spec/app/aspects/screens/fetcher_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Terminus::Aspects::Screens::Fetcher do
     it "answers default image" do
       expect(fetcher.call(slug)).to match(
         filename: "empty_state",
-        image_url: "https://localhost/assets/setup.svg"
+        image_url: "https://localhost/assets/setup.bmp"
       )
     end
 

--- a/spec/app/aspects/synchronizers/device_spec.rb
+++ b/spec/app/aspects/synchronizers/device_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Terminus::Aspects::Synchronizers::Device, :db do
     end
 
     it "fails to update device upon failure" do
-      expect(updater.call(firmware_headers)).to be_failure("Unable to find device by API key.")
+      expect(updater.call(firmware_headers)).to be_failure("Unable to find device by MAC address.")
     end
   end
 end

--- a/spec/app/repositories/device_spec.rb
+++ b/spec/app/repositories/device_spec.rb
@@ -70,17 +70,19 @@ RSpec.describe Terminus::Repositories::Device, :db do
     end
   end
 
-  describe "#update_by_api_key" do
+  describe "#update_by_mac_address" do
     it "updates record with attributes" do
       device
-      update = repository.update_by_api_key device.api_key, label: "Update", friendly_id: "ABCDEF"
+      update = repository.update_by_mac_address device.mac_address,
+                                                label: "Update",
+                                                friendly_id: "ABCDEF"
 
       expect(update).to have_attributes(label: "Update", friendly_id: "ABCDEF")
     end
 
     it "answers record without updates for no attributes" do
       device
-      update = repository.update_by_api_key device.api_key
+      update = repository.update_by_mac_address device.mac_address
 
       expect(update).to eq(device)
     end


### PR DESCRIPTION
## Overview

These changes ensure firmware updates are only applied to the specific device. There also use to be API key information passed back in the responses but is always blank now so have switched to using the MAC address only to maintain integrity between server and device.

## Details

- See commits for details.