### PR TITLE
Updated Dockerfile to Ruby 3.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.4
 
-ARG RUBY_VERSION=3.4.3
+ARG RUBY_VERSION=3.4.4
 
 FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 


### PR DESCRIPTION
## Overview

Necessary to ensure this is in sync with our `.ruby-version` file. Unfortunately, the official Docker image isn't available at the moment. I suspect it'll be live later today which will resolve this issue.
