### PR TITLE
Added PNG image support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -201,7 +201,7 @@ Used for displaying new content to your device. Your device's refresh rate deter
 
 [source,bash]
 ----
-curl "https://localhost:2443/api/display/" \
+curl "https://localhost:2443/api/display" \
      -H 'ID: <redacted>' \
      -H 'Access-Token: <redacted>' \
      -H 'Content-Type: application/json'
@@ -211,7 +211,7 @@ curl "https://localhost:2443/api/display/" \
 
 [source,bash]
 ----
-curl "https://localhost:2443/api/display/" \
+curl "https://localhost:2443/api/display" \
      -H 'ID: <redacted>' \
      -H 'Access-Token: <redacted>' \
      -H 'Content-Type: application/json' \
@@ -222,7 +222,7 @@ curl "https://localhost:2443/api/display/" \
 
 [source,bash]
 ----
-curl "https://localhost:2443/api/display/?base_64=true" \
+curl "https://localhost:2443/api/display?base_64=true" \
      -H 'ID: <redacted>' \
      -H 'Access-Token: <redacted>' \
      -H 'Content-Type: application/json'
@@ -330,14 +330,14 @@ curl -X "POST" "https://localhost:2443/api/screens" \
     -d $'{
  "image": {
    "content": "<p>Test</p>",
-   "file_name": "test"
+   "file_name": "test.png"
  }
 }'
 ----
 
 The `Access-Token` is your device's MAC address. You can obtain this information from the UI.
 
-If you don't supply a `file_name`, the server will generate one for you using a UUID for the file name. You can find all generated images in `public/assets/screens`.
+Both `.png` or `.bmp` extensions are suppored for the `file_name` key. If you don't supply a `file_name`, the server will generate one for you using a UUID for the file name. You can find all generated images in `public/assets/screens`.
 ====
 
 .Response
@@ -346,7 +346,7 @@ If you don't supply a `file_name`, the server will generate one for you using a 
 [source,json]
 ----
 {
-  "path": "$HOME/Engineering/terminus/public/assets/screens/A1B2C3D4E5F6/test.bmp"
+  "path": "$HOME/Engineering/terminus/public/assets/screens/A1B2C3D4E5F6/test.png"
 }
 ----
 ====
@@ -440,12 +440,13 @@ fetcher.call device.slug
 # 💡 "A1B2C3D4E5F6" would be your device slug (i.e. collapsed MAC Address).
 creator = Terminus::Screens::Creator.new
 creator.call "<p>Test</p>",
-             Pathname(Hanami.app[:settings].screens_root).join("A1B2C3D4E5F6/%<name>s.bmp")
-#<Pathname:terminus/public/assets/screens/A1B2C3D4E5F6/5af3f06-775f-4ae9-8bb1-246d9a5200c9.bmp>
+             Pathname(Hanami.app[:settings].screens_root).join("A1B2C3D4E5F6/%<name>s.png")
+#<Pathname:terminus/public/assets/screens/A1B2C3D4E5F6/5af3f06-775f-4ae9-8bb1-246d9a5200c9.png>
 
 # To generate image with specific name.
-creator.call "<p>Test.</p>", Pathname(Hanami.app[:settings].screens_root).join("demo.bmp")
-#<Pathname:terminus/public/assets/screens/demo.bmp>
+creator.call "<p>Test.</p>",
+             Pathname(Hanami.app[:settings].screens_root).join("A1B2C3D4E5F6/demo.png")
+#<Pathname:terminus/public/assets/screens/demo.png>
 ----
 
 When creating images, you might find this HTML template valuable as a starting point as this let's you use the full capabilities of HTML to create new images for your device.

--- a/app/actions/designer/create.rb
+++ b/app/actions/designer/create.rb
@@ -32,7 +32,7 @@ module Terminus
         def render_text template, response
           id, content = template.values_at :id, :content
 
-          creator.call content, settings.previews_root.mkpath.join("#{id}.bmp")
+          creator.call content, settings.previews_root.mkpath.join("#{id}.png")
 
           response.body = content.strip
           response.status = 201

--- a/app/aspects/screens/designer/event_stream.rb
+++ b/app/aspects/screens/designer/event_stream.rb
@@ -6,7 +6,7 @@ require "mini_magick"
 module Terminus
   module Aspects
     module Screens
-      module Editor
+      module Designer
         # Renders device preview image event streams.
         class EventStream
           include Deps[:settings]

--- a/app/aspects/screens/designer/middleware.rb
+++ b/app/aspects/screens/designer/middleware.rb
@@ -8,7 +8,7 @@ require_relative "event_stream"
 module Terminus
   module Aspects
     module Screens
-      module Editor
+      module Designer
         # Streams Server Side Events (SSE) for device screen previews.
         class Middleware
           include Initable[

--- a/app/aspects/screens/editor/event_stream.rb
+++ b/app/aspects/screens/editor/event_stream.rb
@@ -10,7 +10,7 @@ module Terminus
         # Renders device preview image event streams.
         class EventStream
           include Deps[:settings]
-          include Initable[%i[req id], type: :bmp, imager: MiniMagick::Image, kernel: Kernel]
+          include Initable[%i[req id], type: :png, imager: MiniMagick::Image, kernel: Kernel]
 
           def each
             kernel.loop do

--- a/app/aspects/screens/fetcher.rb
+++ b/app/aspects/screens/fetcher.rb
@@ -9,13 +9,14 @@ module Terminus
     module Screens
       # Fetches latest image for rendering on device screen.
       class Fetcher
-        include Initable[encryptions: [:base_64]]
+        include Initable[types: proc { Terminus::Screens::TYPES }, encryptions: [:base_64]]
+
         include Deps[:settings, :assets]
 
         using Refinements::Pathname
 
         def call slug, encryption: nil
-          image_path = settings.screens_root.join(slug).files("*.bmp").max_by(&:mtime)
+          image_path = settings.screens_root.join(slug).files(supported_types).max_by(&:mtime)
 
           return default unless image_path
 
@@ -33,6 +34,8 @@ module Terminus
         end
 
         def default = {filename: "empty_state", image_url: "#{settings.api_uri}/assets/setup.bmp"}
+
+        def supported_types = %(*.{#{types.join ","}})
       end
     end
   end

--- a/config/app.rb
+++ b/config/app.rb
@@ -18,7 +18,7 @@ module Terminus
       end
     end
 
-    config.inflections { it.acronym "IP" }
+    config.inflections { it.acronym "IP", "TYPES" }
 
     config.actions.content_security_policy.then do |csp|
       csp[:manifest_src] = "'self'"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../app/aspects/screens/editor/middleware"
+require_relative "../app/aspects/screens/designer/middleware"
 
 module Terminus
   # The application base routes.
@@ -38,6 +38,6 @@ module Terminus
     slice(:health, at: "/up") { root to: "show" }
 
     use Rack::Static, root: "public", urls: ["/.well-known/security.txt"]
-    use Aspects::Screens::Editor::Middleware, pattern: %r(/preview/(?<id>\d+))
+    use Aspects::Screens::Designer::Middleware, pattern: %r(/preview/(?<id>\d+))
   end
 end

--- a/lib/terminus/screens/greyscaler.rb
+++ b/lib/terminus/screens/greyscaler.rb
@@ -1,23 +1,42 @@
 # frozen_string_literal: true
 
+require "dry/monads"
 require "mini_magick"
+require "refinements/array"
 
 module Terminus
   module Screens
     # Converts image to greyscale BMP image.
     class Greyscaler
-      def initialize randomizer: Randomizer, client: MiniMagick
+      include Dry::Monads[:result]
+
+      using Refinements::Array
+
+      def initialize types: TYPES, randomizer: Randomizer, client: MiniMagick
+        @types = types
         @randomizer = randomizer
         @client = client
       end
 
       def call input_path, output_path
-        uniquify(output_path).tap { |unique_path| convert input_path, unique_path }
+        formatted_output_path = uniquify output_path
+        extension = output_path.extname.delete_prefix "."
+
+        typed_path_for(formatted_output_path, extension).bind do |typed_output_path|
+          process input_path, typed_output_path, formatted_output_path
+        end
       end
 
       private
 
-      def convert input_path, output_path
+      def process input_path, typed_output_path, output_path
+        convert input_path, typed_output_path
+        Success output_path
+      rescue MiniMagick::Error => error
+        Failure error.message
+      end
+
+      def convert input_path, typed_output_path
         client.convert do |converter|
           converter << input_path.to_s
           converter.dither << "FloydSteinberg"  # Popular black-n-white dithering algorithm.
@@ -25,13 +44,23 @@ module Terminus
           converter.depth 1                     # Applies 1-bit depth.
           converter.colors 2                    # Enforces black-n-white by limiting to two colors.
           converter.strip                       # Removes all metadata to reduce file size.
-          converter << "bmp3:#{output_path}"    # Forces BMP, Version 3 file output.
+          converter << typed_output_path        # Saves to path using specific image type.
         end
       end
 
       def uniquify(path) = Pathname format(path.to_s, name: randomizer.call)
 
-      attr_reader :randomizer, :client
+      def typed_path_for path, extension
+        return type_error extension unless types.include? extension
+
+        Success "#{extension == "bmp" ? "bmp3" : extension}:#{path}"
+      end
+
+      def type_error value
+        Failure %(Invalid image type: #{value.inspect}. Use: #{types.to_usage "or"}.)
+      end
+
+      attr_reader :types, :randomizer, :client
     end
   end
 end

--- a/lib/terminus/screens/types.rb
+++ b/lib/terminus/screens/types.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Screens
+    TYPES = %w[bmp png].freeze
+  end
+end

--- a/spec/app/actions/designer/create_spec.rb
+++ b/spec/app/actions/designer/create_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Terminus::Actions::Designer::Create do
 
     it "creates preview image" do
       Rack::MockRequest.new(action).post "", "HTTP_HX_REQUEST" => true, params: parameters
-      expect(temp_dir.join("123.bmp").exist?).to be(true)
+      expect(temp_dir.join("123.png").exist?).to be(true)
     end
 
     it "answers created status" do

--- a/spec/app/aspects/screens/designer/event_stream_spec.rb
+++ b/spec/app/aspects/screens/designer/event_stream_spec.rb
@@ -2,7 +2,7 @@
 
 require "hanami_helper"
 
-RSpec.describe Terminus::Aspects::Screens::Editor::EventStream do
+RSpec.describe Terminus::Aspects::Screens::Designer::EventStream do
   using Refinements::Pathname
 
   subject(:event_stream) { described_class.new "test", type: :png, kernel: }

--- a/spec/app/aspects/screens/designer/middleware_spec.rb
+++ b/spec/app/aspects/screens/designer/middleware_spec.rb
@@ -2,7 +2,7 @@
 
 require "hanami_helper"
 
-RSpec.describe Terminus::Aspects::Screens::Editor::Middleware do
+RSpec.describe Terminus::Aspects::Screens::Designer::Middleware do
   subject(:middleware) { described_class.new application, pattern: %r(/preview/(?<id>\d+)) }
 
   let(:application) { proc { [200, {}, []] } }
@@ -19,13 +19,13 @@ RSpec.describe Terminus::Aspects::Screens::Editor::Middleware do
             "Cache-Control" => "no-cache",
             "Connection" => "keep-alive"
           },
-          instance_of(Terminus::Aspects::Screens::Editor::EventStream)
+          instance_of(Terminus::Aspects::Screens::Designer::EventStream)
         )
       )
     end
 
     it "passes ID to event stream" do
-      event_stream = class_spy Terminus::Aspects::Screens::Editor::EventStream
+      event_stream = class_spy Terminus::Aspects::Screens::Designer::EventStream
       middleware = described_class.new(application, pattern: %r(/preview/(?<id>\d+)), event_stream:)
       environment = Rack::MockRequest.env_for "/preview/123", method: :get
       middleware.call environment

--- a/spec/lib/terminus/screens/creator_spec.rb
+++ b/spec/lib/terminus/screens/creator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Terminus::Screens::Creator do
     end
 
     it "answers image path" do
-      expect(creator.call(content, path)).to eq(path)
+      expect(creator.call(content, path)).to be_success(path)
     end
   end
 end

--- a/spec/requests/screens_spec.rb
+++ b/spec/requests/screens_spec.rb
@@ -4,7 +4,7 @@ require "hanami_helper"
 
 RSpec.describe "/api/screens", :db do
   let(:device) { Factory[:device] }
-  let(:path) { temp_dir.join device.slug, "rspec_test.bmp" }
+  let(:path) { temp_dir.join device.slug, "rspec_test.png" }
 
   it "creates image with random name" do
     post routes.path(:api_screens_create),
@@ -17,7 +17,7 @@ RSpec.describe "/api/screens", :db do
 
   it "creates image with specific name" do
     post routes.path(:api_screens_create),
-         {image: {content: "<p>Test</p>"}, filename: "test.bmp"}.to_json,
+         {image: {content: "<p>Test</p>", file_name: "test.bmp"}}.to_json,
          "CONTENT_TYPE" => "application/json",
          "HTTP_ACCESS_TOKEN" => device.api_key
 
@@ -58,5 +58,22 @@ RSpec.describe "/api/screens", :db do
          "HTTP_ACCESS_TOKEN" => device.api_key
 
     expect(last_response.status).to eq(400)
+  end
+
+  context "with invalid file name" do
+    before do
+      post routes.path(:api_screens_create),
+           {image: {content: "Test.", file_name: "test"}}.to_json,
+           "CONTENT_TYPE" => "application/json",
+           "HTTP_ACCESS_TOKEN" => device.api_key
+    end
+
+    it "answers bad request status" do
+      expect(last_response.status).to eq(400)
+    end
+
+    it "answers error" do
+      expect(json_payload).to match(error: /invalid image type/i)
+    end
   end
 end


### PR DESCRIPTION
## Overview

This provides support for PNG images across the board: console, UI, and API. You can now mix-n-match using BMP or PNG images. This also defaults behavior to PNG images since they are smaller in size so there is a nice memory performance boost too.

## Details

- See commits for details.