### PR TITLE
Added Screen API support for image URIs and encoded content

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,6 +14,7 @@
 :ruby_link: link:https://www.ruby-lang.org[Ruby]
 :trmnl_link: link:https://usetrmnl.com[TRMNL]
 :yjit_link: link:https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md[YJIT]
+:image_magick_geometry_link: link:https://www.imagemagick.org/script/command-line-processing.php#geometry[ImageMagick Geometry]
 
 = Terminus
 
@@ -306,20 +307,11 @@ curl "https://localhost:2443/api/setup/" \
 
 ==== Screens
 
-Used for generating new device screens by supplying HTML content for rendering, screenshotting, and grey scaling to render properly on your device.
+Used for generating new device screens by supplying HTML content for rendering, screenshotting, and grey scaling to render properly on your device. Both `.png` or `.bmp` extensions are suppored for the `file_name` key. If you don't supply a `file_name`, the server will generate one for you using a UUID for the file name. You can find all generated images in `public/assets/screens`.
 
-This endpoint supports full HTML so you can supply CSS styles, full DOM, etc. At a minimum, you'll want to use the following to prevent white borders showing up around your generated screens:
+When making requests, the `Access-Token` is your device's MAC address. You can obtain this information from the UI.
 
-[source,css]
-----
-* {
-  margin: 0;
-}
-----
-
-🎗️ You can use the UI Editor to build custom screens in real-time for faster feedback. The result of your work can be supplied to this endpoint to create a new screen for display on your device.
-
-.Request
+.Request (HTML Content)
 [%collapsible]
 ====
 [source,bash]
@@ -330,14 +322,62 @@ curl -X "POST" "https://localhost:2443/api/screens" \
     -d $'{
  "image": {
    "content": "<p>Test</p>",
-   "file_name": "test.png"
+   "file_name": "demo.png"
  }
 }'
 ----
 
-The `Access-Token` is your device's MAC address. You can obtain this information from the UI.
+Full HTML is supported so you can supply CSS styles, full DOM, etc. At a minimum, you'll want to use the following to prevent white borders showing up around your generated screens:
 
-Both `.png` or `.bmp` extensions are suppored for the `file_name` key. If you don't supply a `file_name`, the server will generate one for you using a UUID for the file name. You can find all generated images in `public/assets/screens`.
+[source,css]
+----
+* {
+  margin: 0;
+}
+----
+
+Don't forget that you can use the Designer within the UI to build custom screens in real-time for faster feedback. The result of your work can be supplied to this endpoint to create a new screen for display on your device.
+====
+
+.Request (URI)
+[%collapsible]
+====
+[source,bash]
+----
+curl -X "POST" "https://localhost:2443/api/screens" \
+     -H 'Access-Token: <redacted>' \
+     -H 'Content-Type: application/json' \
+     -d $'{
+  "image": {
+    "uri": "https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png",
+    "file_name": "demo.png",
+    "dimensions": "800x480!"
+  }
+}'
+----
+
+The `dimensions` parameter is optional and defaults to `800x480` when not supplied. You can use the full {image_magick_geometry_link} syntax as the value.
+====
+
+.Request (Base64 Encoded Data)
+[%collapsible]
+====
+
+[source,bash]
+----
+curl -X "POST" "https://localhost:2443/api/screens" \
+     -H 'Access-Token: <redacted>' \
+     -H 'Content-Type: application/json' \
+     -d $'{
+  "image": {
+    "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAAXNSR0IArs4c6QAAAAtJREFUCFtjYGAAAAADAAHc7H1IAAAAAElFTkSuQmCC"
+    "file_name": "demo.png",
+    "dimensions": "800x480!"
+  }
+}'
+----
+
+The `dimensions` parameter is optional and defaults to `800x480` when not supplied. You can use the full {image_magick_geometry_link} syntax as the value.
 ====
 
 .Response
@@ -346,9 +386,11 @@ Both `.png` or `.bmp` extensions are suppored for the `file_name` key. If you do
 [source,json]
 ----
 {
-  "path": "$HOME/Engineering/terminus/public/assets/screens/A1B2C3D4E5F6/test.png"
+  "path": "$HOME/Engineering/terminus/public/assets/screens/A1B2C3D4E5F6/demo.png"
 }
 ----
+
+No matter what parameters you use for this request, you'll always get a path (unless an error is encountered).
 ====
 
 ==== Logs

--- a/app/actions/api/screens/create.rb
+++ b/app/actions/api/screens/create.rb
@@ -21,8 +21,11 @@ module Terminus
 
           params do
             required(:image).hash do
-              required(:content).filled :string
+              optional(:content).filled :string
+              optional(:uri).filled :string
+              optional(:data).filled :string
               optional(:file_name).filled :string
+              optional(:dimensions).filled :string
             end
           end
 
@@ -40,7 +43,10 @@ module Terminus
           private
 
           def save device, image, response
-            result = creator.call image[:content], output_path(device.slug, image)
+            result = creator.call(
+              {dimensions: "800x480"}.merge(image),
+              output_path(device.slug, image)
+            )
 
             if result.success?
               response.with body: {path: result.success}.to_json, status: 200

--- a/app/actions/designer/create.rb
+++ b/app/actions/designer/create.rb
@@ -32,7 +32,7 @@ module Terminus
         def render_text template, response
           id, content = template.values_at :id, :content
 
-          creator.call content, settings.previews_root.mkpath.join("#{id}.png")
+          creator.call({content:}, settings.previews_root.mkpath.join("#{id}.png"))
 
           response.body = content.strip
           response.status = 201

--- a/config/app.rb
+++ b/config/app.rb
@@ -18,7 +18,7 @@ module Terminus
       end
     end
 
-    config.inflections { it.acronym "IP", "TYPES" }
+    config.inflections { it.acronym "IP", "TYPES", "URI" }
 
     config.actions.content_security_policy.then do |csp|
       csp[:manifest_src] = "'self'"

--- a/config/app.rb
+++ b/config/app.rb
@@ -18,7 +18,7 @@ module Terminus
       end
     end
 
-    config.inflections { it.acronym "IP", "TYPES", "URI" }
+    config.inflections { it.acronym "HTML", "IP", "TYPES", "URI" }
 
     config.actions.content_security_policy.then do |csp|
       csp[:manifest_src] = "'self'"

--- a/lib/terminus/screens/creator.rb
+++ b/lib/terminus/screens/creator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+
+module Terminus
+  module Screens
+    # Saves Base64 encoded content as image.
+    class Creator
+      include Dry::Monads[:result]
+
+      def initialize decoder: Decoder.new, html_saver: HTMLSaver.new, uri_saver: URISaver.new
+        @decoder = decoder
+        @html_saver = html_saver
+        @uri_saver = uri_saver
+      end
+
+      def call parameters, output_path
+        case parameters
+          in content: then html_saver.call content, output_path
+          in uri:, dimensions: then uri_saver.call uri, output_path, dimensions
+          in data:, dimensions: then decoder.call data, output_path, dimensions
+          else Failure "Invalid screen parameters: #{parameters.inspect}."
+        end
+      end
+
+      private
+
+      attr_reader :decoder, :html_saver, :uri_saver
+    end
+  end
+end

--- a/lib/terminus/screens/decoder.rb
+++ b/lib/terminus/screens/decoder.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "base64"
+require "dry/monads"
+require "mini_magick"
+
+module Terminus
+  module Screens
+    # Saves Base64 encoded content as image.
+    class Decoder
+      include Dry::Monads[:result]
+
+      def initialize client: MiniMagick::Image, decoder: Base64, greyscaler: Greyscaler.new
+        @client = client
+        @decoder = decoder
+        @greyscaler = greyscaler
+      end
+
+      def call content, output_path, dimensions = "800x480"
+        Tempfile.create ["uri_saver-", output_path.extname] do |file|
+          path = file.path
+          save(content, path, dimensions).bind { greyscaler.call path, output_path }
+        end
+      end
+
+      private
+
+      attr_reader :client, :decoder, :greyscaler
+
+      def save content, path, dimensions
+        Pathname(path).binwrite decoder.strict_decode64(content)
+        Success client.open(path).resize(dimensions).write(path)
+      rescue StandardError => error
+        Failure error.message
+      end
+    end
+  end
+end

--- a/lib/terminus/screens/html_saver.rb
+++ b/lib/terminus/screens/html_saver.rb
@@ -3,7 +3,7 @@
 module Terminus
   module Screens
     # Creates device image.
-    class Creator
+    class HTMLSaver
       include Dependencies[:sanitizer]
 
       def initialize(screensaver: Screensaver.new, greyscaler: Greyscaler.new, **)

--- a/lib/terminus/screens/uri_saver.rb
+++ b/lib/terminus/screens/uri_saver.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+require "mini_magick"
+
+module Terminus
+  module Screens
+    # Saves URI as image.
+    class URISaver
+      include Dry::Monads[:result]
+
+      def initialize client: MiniMagick::Image, greyscaler: Greyscaler.new
+        @client = client
+        @greyscaler = greyscaler
+      end
+
+      def call uri, output_path, dimensions = "800x480"
+        Tempfile.create ["uri_saver-", output_path.extname] do |file|
+          path = file.path
+          save(uri, path, dimensions).bind { greyscaler.call path, output_path }
+        end
+      end
+
+      private
+
+      attr_reader :client, :greyscaler
+
+      def save uri, path, dimensions
+        Success client.open(uri).resize(dimensions).write(path)
+      rescue StandardError => error
+        Failure error.message
+      end
+    end
+  end
+end

--- a/spec/lib/terminus/screens/creator_spec.rb
+++ b/spec/lib/terminus/screens/creator_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+require "mini_magick"
+
+RSpec.describe Terminus::Screens::Creator do
+  subject(:saver) { described_class.new }
+
+  include_context "with temporary directory"
+
+  describe "#call" do
+    let(:content) { Base64.strict_encode64 SPEC_ROOT.join("support/fixtures/test.png").read }
+    let(:output_path) { temp_dir.join "test.png" }
+
+    it "saves HTML as image" do
+      saver.call({content: "<h1>Test</h1>"}, output_path)
+      image = MiniMagick::Image.open output_path
+
+      expect(image).to have_attributes(width: 800, height: 480, type: "PNG", exif: {})
+    end
+
+    it "saves URI as image" do
+      saver.call(
+        {uri: SPEC_ROOT.join("support/fixtures/test.png"), dimensions: "50x50"},
+        output_path
+      )
+
+      image = MiniMagick::Image.open output_path
+
+      expect(image).to have_attributes(width: 50, height: 50, type: "PNG", exif: {})
+    end
+
+    it "saves encoded image" do
+      data = Base64.strict_encode64 SPEC_ROOT.join("support/fixtures/test.png").read
+      saver.call({data:, dimensions: "50x50"}, output_path)
+      image = MiniMagick::Image.open output_path
+
+      expect(image).to have_attributes(width: 50, height: 50, type: "PNG", exif: {})
+    end
+
+    it "answers failure with invalid parameters" do
+      expect(saver.call({bogus: :danger}, output_path)).to be_failure(
+        "Invalid screen parameters: {bogus: :danger}."
+      )
+    end
+  end
+end

--- a/spec/lib/terminus/screens/decoder_spec.rb
+++ b/spec/lib/terminus/screens/decoder_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+require "mini_magick"
+
+RSpec.describe Terminus::Screens::Decoder do
+  subject(:saver) { described_class.new }
+
+  include_context "with temporary directory"
+
+  describe "#call" do
+    let(:content) { Base64.strict_encode64 SPEC_ROOT.join("support/fixtures/test.png").read }
+    let(:output_path) { temp_dir.join "test.png" }
+
+    it "saves file" do
+      saver.call content, output_path
+      image = MiniMagick::Image.open output_path
+
+      expect(image).to have_attributes(width: 480, height: 480, type: "PNG", exif: {})
+    end
+
+    it "saves with custom dimensions" do
+      saver.call content, output_path, "800x480!"
+      image = MiniMagick::Image.open output_path
+
+      expect(image).to have_attributes(width: 800, height: 480, type: "PNG", exif: {})
+    end
+
+    it "answers image path" do
+      expect(saver.call(content, output_path)).to be_success(output_path)
+    end
+
+    it "answers failure with image can't be processed" do
+      client = class_double MiniMagick::Image
+      allow(client).to receive(:open).and_raise(MiniMagick::Error, "Danger!")
+      saver = described_class.new(client:)
+
+      expect(saver.call(content, output_path)).to be_failure("Danger!")
+    end
+  end
+end

--- a/spec/lib/terminus/screens/html_saver_spec.rb
+++ b/spec/lib/terminus/screens/html_saver_spec.rb
@@ -2,7 +2,7 @@
 
 require "hanami_helper"
 
-RSpec.describe Terminus::Screens::Creator do
+RSpec.describe Terminus::Screens::HTMLSaver do
   subject(:creator) { described_class.new }
 
   include_context "with temporary directory"

--- a/spec/lib/terminus/screens/uri_saver_spec.rb
+++ b/spec/lib/terminus/screens/uri_saver_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+require "mini_magick"
+
+RSpec.describe Terminus::Screens::URISaver do
+  subject(:saver) { described_class.new }
+
+  include_context "with temporary directory"
+
+  describe "#call" do
+    let(:fixture_path) { SPEC_ROOT.join "support/fixtures/test.png" }
+    let(:output_path) { temp_dir.join "test.png" }
+
+    it "saves file" do
+      saver.call fixture_path, output_path
+      image = MiniMagick::Image.open output_path
+
+      expect(image).to have_attributes(width: 480, height: 480, type: "PNG", exif: {})
+    end
+
+    it "saves URL" do
+      saver.call "https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png", output_path
+      image = MiniMagick::Image.open output_path
+
+      expect(image).to have_attributes(width: 480, height: 480, type: "PNG", exif: {})
+    end
+
+    it "saves with custom dimensions" do
+      saver.call fixture_path, output_path, "800x480!"
+      image = MiniMagick::Image.open output_path
+
+      expect(image).to have_attributes(width: 800, height: 480, type: "PNG", exif: {})
+    end
+
+    it "answers image path" do
+      expect(saver.call(fixture_path, output_path)).to be_success(output_path)
+    end
+
+    it "answers failure with image can't be processed" do
+      client = class_double MiniMagick::Image
+      allow(client).to receive(:open).and_raise(MiniMagick::Error, "Danger!")
+      saver = described_class.new(client:)
+
+      expect(saver.call("bogus", output_path)).to be_failure("Danger!")
+    end
+  end
+end

--- a/spec/requests/screens_spec.rb
+++ b/spec/requests/screens_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "/api/screens", :db do
   let(:device) { Factory[:device] }
   let(:path) { temp_dir.join device.slug, "rspec_test.png" }
 
-  it "creates image with random name" do
+  it "creates image from HTML with random name" do
     post routes.path(:api_screens_create),
          {image: {content: "<p>Test</p>"}}.to_json,
          "CONTENT_TYPE" => "application/json",
@@ -15,13 +15,44 @@ RSpec.describe "/api/screens", :db do
     expect(Pathname(json_payload[:path]).exist?).to be(true)
   end
 
-  it "creates image with specific name" do
+  it "creates image from HTML with specific name" do
     post routes.path(:api_screens_create),
          {image: {content: "<p>Test</p>", file_name: "test.bmp"}}.to_json,
          "CONTENT_TYPE" => "application/json",
          "HTTP_ACCESS_TOKEN" => device.api_key
 
     expect(Pathname(json_payload[:path]).exist?).to be(true)
+  end
+
+  it "creates image from URI" do
+    post routes.path(:api_screens_create),
+         {image: {uri: SPEC_ROOT.join("support/fixtures/test.png")}}.to_json,
+         "CONTENT_TYPE" => "application/json",
+         "HTTP_ACCESS_TOKEN" => device.api_key
+
+    expect(Pathname(json_payload[:path]).exist?).to be(true)
+  end
+
+  it "creates image from Base64 encoded data" do
+    data = Base64.strict_encode64 SPEC_ROOT.join("support/fixtures/test.png").read
+
+    post routes.path(:api_screens_create),
+         {image: {data:}}.to_json,
+         "CONTENT_TYPE" => "application/json",
+         "HTTP_ACCESS_TOKEN" => device.api_key
+
+    expect(Pathname(json_payload[:path]).exist?).to be(true)
+  end
+
+  it "creates image with specific dimensions" do
+    post routes.path(:api_screens_create),
+         {image: {uri: SPEC_ROOT.join("support/fixtures/test.png"), dimensions: "50x100!"}}.to_json,
+         "CONTENT_TYPE" => "application/json",
+         "HTTP_ACCESS_TOKEN" => device.api_key
+
+    image = MiniMagick::Image.open Pathname(json_payload[:path])
+
+    expect(image).to have_attributes(width: 50, height: 100)
   end
 
   it "answers bad request for unknown device" do
@@ -48,7 +79,9 @@ RSpec.describe "/api/screens", :db do
          "CONTENT_TYPE" => "application/json",
          "HTTP_ACCESS_TOKEN" => device.api_key
 
-    expect(json_payload).to eq(image: {content: ["is missing"]})
+    expect(json_payload).to eq(
+      error: %(Invalid screen parameters: {dimensions: "800x480", file_name: "test"}.)
+    )
   end
 
   it "answers bad request for partial body" do


### PR DESCRIPTION
## Overview

This addresses community feedback by making the Screens API more robust in being able to handle HTML along with newly added support for Image URIs and Base64 encoded content.
 
## Details

- See commits for details.
- See the newly updated [Screens API Documentation](https://github.com/usetrmnl/byos_hanami?tab=readme-ov-file#screens) for request examples.
- Resolves Issue #108.