### PR TITLE
Fixed Gemfile.lock after Inspectable gem was added

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,7 +553,7 @@ DEPENDENCIES
   http-fake (~> 4.1)
   infusible (~> 4.2)
   initable (~> 0.3)
-  inspectable (~> 0.3.0)
+  inspectable (~> 0.3)
   irb-kit (~> 1.1)
   launchy (~> 3.1)
   localhost (~> 1.3)


### PR DESCRIPTION
## Overview
This fixes #115. The dependency was added in e62f590a925cce8b02300fd8615ddcdb428069b8.

Without this fix, `bundle install` won't install anything in the Docker image and the app will fail to start entirely.
