### PR TITLE
Added dev stage to Dockerfile. Made compose more developer friendly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,66 +4,94 @@ ARG RUBY_VERSION=3.4.4
 
 FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
-ENV RACK_ENV=production
-ENV HANAMI_ENV=production
-ENV HANAMI_SERVE_ASSETS=true
-ENV BUNDLE_DEPLOYMENT=1
 ENV BUNDLE_PATH=/usr/local/bundle
-ENV BUNDLE_WITHOUT="development:quality:test:tools"
-
 WORKDIR /app
 
+# Combined repository setup and package installation
 RUN <<STEPS
-  apt-get update -qq \
-  && apt-get install --no-install-recommends -y \
-  chromium \
-  curl \
-  imagemagick \
-  libjemalloc2 \
-  nodejs \
-  npm \
-  postgresql-client \
-  tmux \
-  && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+  apt-get update -qq
+  apt-get install -y --no-install-recommends curl ca-certificates gnupg2 lsb-release
+  # Setup PostgreSQL repository
+  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+  # Setup Node.js repository and install runtime dependencies
+  curl -fsSL https://deb.nodesource.com/setup_23.x | bash -
+  apt-get update -qq
+  apt-get install -y --no-install-recommends \
+      chromium \
+      imagemagick \
+      libjemalloc2 \
+      tmux \
+      postgresql-client-17 \
+      nodejs
+  rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 STEPS
 
+# Build stage for installing dependencies
 FROM base AS build
 
+# Install build dependencies
 RUN <<STEPS
-  apt-get update -qq \
-  && apt-get install --no-install-recommends -y build-essential \
-  libpq-dev \
-  libyaml-dev \
-  pkg-config \
-  && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+  apt-get update -qq
+  apt-get install -y --no-install-recommends \
+      build-essential \
+      libpq-dev \
+      libyaml-dev \
+      pkg-config
+  rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 STEPS
 
+# Copy dependency files
 COPY .ruby-version Gemfile Gemfile.lock .node-version package.json package-lock.json ./
 
+# Install all dependencies
 RUN <<STEPS
   bundle install
   npm install
   rm -rf "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 STEPS
 
-COPY . .
-FROM base
-COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
-COPY --from=build /app /app
+# Development stage
+FROM base AS development
 
+ENV RACK_ENV=development
+ENV HANAMI_ENV=development
+ENV HANAMI_SERVE_ASSETS=true
+
+# Copy installed dependencies from build stage
+COPY --from=build ${BUNDLE_PATH} ${BUNDLE_PATH}
+
+# Create necessary directories
 RUN <<STEPS
   mkdir -p /app/log
   mkdir -p /app/tmp
 STEPS
 
-RUN groupadd --system --gid 1000 app && \
-    useradd app --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R app:app . public log tmp
+# Production stage
+FROM base AS production
+
+ENV RACK_ENV=production
+ENV HANAMI_ENV=production
+ENV HANAMI_SERVE_ASSETS=true
+ENV BUNDLE_DEPLOYMENT=1
+ENV BUNDLE_WITHOUT="development:quality:test:tools"
+
+# Copy installed dependencies and application files
+COPY --from=build ${BUNDLE_PATH} ${BUNDLE_PATH}
+COPY --from=build /app/node_modules /app/node_modules
+COPY . .
+
+# Create directories and setup permissions
+RUN <<STEPS
+  mkdir -p /app/log
+  mkdir -p /app/tmp
+  groupadd --system --gid 1000 app
+  useradd app --uid 1000 --gid 1000 --create-home --shell /bin/bash
+  chown -R app:app . public log tmp
+STEPS
 
 USER 1000:1000
 
 ENTRYPOINT ["/app/bin/docker/entrypoint"]
-
 EXPOSE 2300
-
 CMD ["bundle", "exec", "overmind", "start", "--port-step", "10", "--can-die", "migrate,assets"]

--- a/bin/docker/dev
+++ b/bin/docker/dev
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+./bin/setup
+[ -e ./.overmind.sock ] && rm ./.overmind.sock
+bundle exec overmind start --port-step 10 --procfile Procfile.dev --can-die assets,migrate

--- a/bin/setup
+++ b/bin/setup
@@ -20,7 +20,8 @@ class Runner
       setup_development_procfile
       step "Installing dependencies...", "bundle install"
       step "Installing packages...", "npm install"
-      step "Configuring databases...", "hanami db prepare"
+      step "Configuring databases...", "bundle exec hanami db prepare"
+      step "Compiling assets...", "bundle exec hanami assets compile"
     end
   end
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,15 +5,20 @@ services:
     init: true
     build:
       context: .
+      target: development
+    env_file: .env.docker
     environment:
-      API_URI: ${API_URI}
-      DATABASE_URL: postgres://${PG_USER}:${PG_PASSWORD}@database:5432/${PG_DATABASE}
+      API_URI: ${API_URI-http://localhost:2300}
+      DATABASE_URL: postgres://${PG_USER:-postgres}:${PG_PASSWORD:-password}@database:5432/${PG_DATABASE:-terminus_development}
     ports:
       - "2300:2300"
     restart: unless-stopped
+    volumes:
+      - .:/app
     depends_on:
       database:
         condition: service_healthy
+    command: ["bin/docker/dev"]
     deploy:
       resources:
         limits:
@@ -22,17 +27,19 @@ services:
 
   database:
     image: postgres:17.4
-    restart: unless-stopped
+    env_file: .env.docker
     volumes:
       - database-data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: ${PG_USER}
-      POSTGRES_DB: ${PG_DATABASE}
-      POSTGRES_PASSWORD: ${PG_PASSWORD}
+      POSTGRES_USER: ${PG_USER:-postgres}
+      POSTGRES_DB: ${PG_DATABASE:-terminus_development}
+      POSTGRES_PASSWORD: ${PG_PASSWORD:-password}
+    ports:
+      - "${DB_HOST_PORT:-5432}:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${PG_USER}"]
-      interval: 10s
-      timeout: 5s
+      test: ["CMD-SHELL", "pg_isready -U ${PG_USER:-postgres}"]
+      interval: 5s
+      timeout: 2s
       retries: 5
     deploy:
       resources:


### PR DESCRIPTION
## Overview
* This update provides more ergonomic development and setup experience for those looking to contribute
* To do that we need to make sure the box has the proper software in ruby node and pg client

Opening this PR I see a problem. The build step now only bundles gems with all groups. I need to figure this out.


## Screenshots/Screencasts
![Screenshot 2025-05-26 at 11 38 21 PM](https://github.com/user-attachments/assets/e5579919-7ffb-4a64-a778-3825201c5225)
![Screenshot 2025-05-26 at 11 39 07 PM](https://github.com/user-attachments/assets/e90e6df9-b108-4eb6-87db-b5bcae981b71)



## Details
* Adds a stage to the Dockerfile that can be targeted in the compose file per my conversation with @bkuhlmann in https://github.com/usetrmnl/byos_hanami/issues/66
* Install proper versions of nodejs and pgsql
* Added a step to the setup script to build assets
* Added a docker entrypoint for the dev compose container
* Have compose pull in a `.env.docker` file for increased configurability for local development. For example if I want to change the DB port because I already have postgres installed.
