### PR TITLE
Fixed rendering of Chinese characters within Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.opencontainers.image.description="A TRMNL server."
 LABEL org.opencontainers.image.authors="TRMNL <engineering@usetrmnl.com>"
 LABEL org.opencontainers.image.vendor=TRMNL
 
+ENV LANG=C.UTF-8
 ENV RACK_ENV=production
 ENV HANAMI_ENV=production
 ENV HANAMI_SERVE_ASSETS=true
@@ -24,8 +25,10 @@ RUN <<STEPS
   && apt-get install --no-install-recommends -y \
   chromium \
   curl \
+  fonts-noto-cjk \
   imagemagick \
   libjemalloc2 \
+  locales \
   nodejs \
   npm \
   postgresql-client \


### PR DESCRIPTION
## Overview

Necessary to prevent square boxes showing up for Chinese characters. I opted to use the `fonts-noto-cjk` fonts package, despite being larger in size compared to `fonts-wqy-zenhei`, because it's more comprehensive. This includes the `locales` package for additional support.

I also specified the language as `UTF-8`, despite not being directly related to this fix, for additional clarity.

## Details

- Resolves issue #125.