### PR TITLE
Fixed Dockerfile firmware and screen directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,12 +72,14 @@ COPY --from=build /app /app
 
 RUN <<STEPS
   mkdir -p /app/log
+  mkdir -p /app/public/assets/firmware
+  mkdir -p /app/public/assets/screens
   mkdir -p /app/tmp
 STEPS
 
 RUN groupadd --system --gid 1000 app && \
     useradd app --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R app:app . public log tmp
+    chown -R app:app . log public tmp
 
 USER 1000:1000
 


### PR DESCRIPTION
## Overview

Necessary to prevent directory permission errors when using Docker Compose to build and run Terminus for the first time (this doesn't happen for anyone who's built Terminus before).

This cropped up due to commit: da48f0df3eb3 (Added Docker Compose web firmware and screen asset volumes). Even though ownership was given to the `public` folder, we still needed to create the nested directory structure for the `firmware` and `screens` folders. This resolves that situation.

## Details

- Resolves #136