### PR TITLE
Added explicit DB target for pg ready healthcheck

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -33,7 +33,7 @@ services:
       POSTGRES_DB: ${PG_DATABASE}
       POSTGRES_PASSWORD: ${PG_PASSWORD}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${PG_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${PG_USER} -d ${PG_DATABASE}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fixes #141 

This prevents a potential health check failure loop for a "full stack" docker compose deployment if a user has a db user that does not share the same name as the db itself.

## Overview
Due to how `pg_isready` (apparently) works, the existing testing logic effectively presumes that a user will always have a db user share the same name as the db itself. Given that the user is encouraged to separately define values for the user and the db, this will inevitably lead to the only natural outcome (see visual supplement below). 

## Screenshots/Screencasts
![It's the sideshow bob rake gag](https://kagi.com/proxy/gvVXgAT.gif?c=LeUEJczBkA3eiHIb6Q3EKvm7xgK9kTWVsUs7dSLy-wFaPPl-cErgsvtSJH1Z9Iu4)

## Details
By adding a `-d` flag and passing along the `${PG_DATABASE}` variable already used in the pattern we can remove one more potential footgun from the world.
