### PR TITLE
Fixed Dockerfile missing uploads directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,9 @@ COPY --from=build /app /app
 
 RUN <<STEPS
   mkdir -p /app/log
-  mkdir -p /app/public/assets/firmware
   mkdir -p /app/public/assets/screens
+  mkdir -p /app/public/uploads
+  mkdir -p /app/public/uploads/cache
   mkdir -p /app/tmp
 STEPS
 


### PR DESCRIPTION
## Overview

Necessary to ensure the uploads directory exists for the Docker image as this is necessary for Shrine to be able to properly save attachments.

This also removes the `assets/firmwares` folders since it's no longer used.

## Details

- See Issue #166 for more details.