### PR TITLE
Fix development git clone URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -919,7 +919,7 @@ To contribute, run:
 
 [source,bash]
 ----
-git clone https://github.com/usetrmnl/terminus
+git clone https://github.com/usetrmnl/byos_hanami terminus
 cd terminus
 bin/setup
 ----


### PR DESCRIPTION
## Overview
Small doc fix. Corrects URL for development checkout.

The repo is now located at byos_hanami and aliased to terminus. This was not fixed under the development header section.

## Screenshots/Screencasts
<!-- Optional. Provide supporting image/video. -->
n/a
## Details
<!-- Optional. List the key features/highlights as bullet points. -->
n/a