### PR TITLE
Added Docker ARM 64 GitHub Workflow cross platform build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: QEMU Setup
+        uses: docker/setup-qemu-action@v3
+
       - name: Buildx Setup
         uses: docker/setup-buildx-action@v3
+        with:
+         version: latest
 
       - name: Container Registry Login
         uses: docker/login-action@v3
@@ -38,10 +43,13 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Build and Publish
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Overview

Necessary to build for AMD 64 and ARM 64 in order to support cross platforms builds. This includes:

* Ensuring QEMU is setup for mutli-platform builds.
* Ensuring we are using the latest BuildX and build push action versions.
* Ensuring image layers are cached (i.e. `gha`).

## Details

- Resolves Issue #169.