### PR TITLE
Fixed Dockerfile creation of assets folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ COPY --from=build /app /app
 
 RUN <<STEPS
   mkdir -p /app/log
+  mkdir -p /app/public/assets
   mkdir -p /app/public/uploads
   mkdir -p /app/public/uploads/cache
   mkdir -p /app/tmp


### PR DESCRIPTION
## Overview

This cropped up do to cd5188bf4855 (Removed Docker screen assets) because I forgot that we still must create the assets folder. We got this for free originally, because we were always creating sub-folders but now that the subfolders are gone, we still must create the root folder.

## Details

- Related Issue #186.