### PR TITLE
Fixed sanitizer so that link and script elements are allowed

### DIFF
--- a/lib/terminus/sanitizer.rb
+++ b/lib/terminus/sanitizer.rb
@@ -21,10 +21,12 @@ module Terminus
 
     def configuration = client::Config.merge(defaults, elements:, attributes:)
 
-    def elements = defaults[:elements].including "html", "source", "style"
+    def elements = defaults[:elements].including "html", "link", "script", "source", "style"
 
     def attributes
-      defaults[:attributes].merge "source" => %w[type src srcset sizes media height width]
+      defaults[:attributes].merge "link" => %w[href rel],
+                                  "script" => %w[src],
+                                  "source" => %w[type src srcset sizes media height width]
     end
   end
 end

--- a/spec/lib/terminus/sanitizer_spec.rb
+++ b/spec/lib/terminus/sanitizer_spec.rb
@@ -6,6 +6,24 @@ RSpec.describe Terminus::Sanitizer do
   subject(:sanitizer) { described_class.new }
 
   describe "#call" do
+    it "allows link element with attributes" do
+      source = <<~HTML.squeeze(" ").delete("\n").strip
+        <html><head> <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
+        </head><body></body></html>
+      HTML
+
+      expect(sanitizer.call(source)).to eq(source)
+    end
+
+    it "allows script element with attributes" do
+      source = <<~HTML.squeeze(" ").delete("\n").strip
+        <html><head> <script src="https://usetrmnl.com/js/latest/plugins.js"></script>
+        </head><body></body></html>
+      HTML
+
+      expect(sanitizer.call(source)).to eq(source)
+    end
+
     it "allows style element with attributes" do
       element = <<~HTML.strip
         <html><head>


### PR DESCRIPTION
## Overview

Necessary to ensure you can leverage the [TRMNL Framework](https://usetrmnl.com/framework) when using the Designer and/or Screens API because you'll need to pull in our stylesheet and associated JavaScript code in order for the screen to render properly.

## Screenshots/Screencasts

Here's what this looks like when using the Designer when these changes are applied:

<img width="1594" height="921" alt="2025-08-02_11-46-13-Vivaldi" src="https://github.com/user-attachments/assets/44137bcd-3d28-4689-a9c5-e5802b6143dd" />

## Details

- Resolves #192.
