### PR TITLE
Fixed playlist mirroring when playlist item position are not consecutive

### DIFF
--- a/app/actions/playlists/mirror/update.rb
+++ b/app/actions/playlists/mirror/update.rb
@@ -25,14 +25,23 @@ module Terminus
 
             halt :not_found unless playlist
 
-            device_repository.mirror_playlist parameters.dig(:mirror, :device_ids), playlist.id
-            response.render view, **view_settings(request, playlist)
+            mirror playlist, parameters
+            render playlist, request, response
           end
 
           private
 
+          def mirror playlist, parameters
+            device_repository.mirror_playlist parameters.dig(:mirror, :device_ids), playlist.id
+          end
+
+          def render playlist, request, response
+            htmx.response! response.headers, push_url: routes.path(:playlist, id: playlist.id)
+            response.render view, **view_settings(request, playlist)
+          end
+
           def view_settings request, playlist
-            settings = {playlist:, items: playlist_item_repository.all}
+            settings = {playlist:, items: playlist_item_repository.all_by(playlist_id: playlist.id)}
             settings[:layout] = false if htmx.request? request.env, :request, "true"
             settings
           end

--- a/app/relations/playlist_item.rb
+++ b/app/relations/playlist_item.rb
@@ -12,13 +12,13 @@ module Terminus
       end
 
       def next_item after:, playlist_id:
-        calculation = "position = CASE " \
-                      "WHEN ? >= (SELECT MAX(position) FROM playlist_item) " \
-                      "THEN (SELECT MIN(position) FROM playlist_item) " \
-                      "ELSE ? + 1 " \
-                      "END"
+        scope = where(playlist_id:)
 
-        where(playlist_id:).where(Sequel.lit(calculation, after, after)).one
+        next_or_previous = scope.where { position > after }
+                                .order(:position)
+                                .first
+
+        next_or_previous || scope.order(:position).first
       end
     end
   end

--- a/app/repositories/playlist.rb
+++ b/app/repositories/playlist.rb
@@ -21,6 +21,13 @@ module Terminus
 
       def find_by(**) = with_current_item.where(**).one
 
+      def update_current_item id, item_id
+        playlist.transaction do
+          record = find id
+          record.current_item_id ? record : update(id, current_item_id: item_id)
+        end
+      end
+
       private
 
       def with_current_item = playlist.combine :current_item

--- a/spec/app/actions/playlists/items/create_spec.rb
+++ b/spec/app/actions/playlists/items/create_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Actions::Playlists::Items::Create, :db do
+  subject(:action) { described_class.new }
+
+  describe "#call" do
+    let(:playlist) { Factory[:playlist] }
+    let(:screen) { Factory[:screen, :with_image] }
+    let(:playlist_repository) { Terminus::Repositories::Playlist.new }
+
+    let :params do
+      {
+        playlist_id: playlist.id,
+        playlist_item: {
+          screen_id: screen.id
+        }
+      }
+    end
+
+    it "updates playlist with created item when there is no current item" do
+      playlist_repository
+      Rack::MockRequest.new(action).post("", params:)
+
+      expect(playlist_repository.find(playlist.id)).to have_attributes(
+        current_item_id: kind_of(Integer)
+      )
+    end
+
+    it "fails as unprocessable entity when parameters are invalid" do
+      playlist_repository
+      params.delete :playlist_item
+      response = Rack::MockRequest.new(action).post("", params:)
+
+      expect(response.status).to eq(422)
+    end
+  end
+end

--- a/spec/app/aspects/screens/creators/encoded_spec.rb
+++ b/spec/app/aspects/screens/creators/encoded_spec.rb
@@ -3,7 +3,7 @@
 require "hanami_helper"
 
 RSpec.describe Terminus::Aspects::Screens::Creators::Encoded, :db do
-  subject(:saver) { described_class.new }
+  subject(:creator) { described_class.new }
 
   describe "#call" do
     let :payload do
@@ -18,7 +18,7 @@ RSpec.describe Terminus::Aspects::Screens::Creators::Encoded, :db do
     let(:model) { Factory[:model] }
 
     it "answers screen" do
-      result = saver.call payload
+      result = creator.call payload
 
       expect(result.success).to have_attributes(
         model_id: model.id,
@@ -37,7 +37,7 @@ RSpec.describe Terminus::Aspects::Screens::Creators::Encoded, :db do
     end
 
     it "answers failure with database error" do
-      result = saver.call payload.with(name: nil)
+      result = creator.call payload.with(name: nil)
       expect(result.failure).to match(/null value/)
     end
   end

--- a/spec/app/aspects/screens/creators/html_spec.rb
+++ b/spec/app/aspects/screens/creators/html_spec.rb
@@ -3,7 +3,7 @@
 require "hanami_helper"
 
 RSpec.describe Terminus::Aspects::Screens::Creators::HTML, :db do
-  subject(:saver) { described_class.new }
+  subject(:creator) { described_class.new }
 
   describe "#call" do
     let(:model) { Factory[:model] }
@@ -30,7 +30,7 @@ RSpec.describe Terminus::Aspects::Screens::Creators::HTML, :db do
     end
 
     it "answers screen" do
-      result = saver.call payload
+      result = creator.call payload
 
       expect(result.success).to have_attributes(
         model_id: model.id,
@@ -49,14 +49,14 @@ RSpec.describe Terminus::Aspects::Screens::Creators::HTML, :db do
     end
 
     it "answers failure with database error" do
-      result = saver.call payload.with(name: nil)
+      result = creator.call payload.with(name: nil)
       expect(result.failure).to match(/null value/)
     end
   end
 
   describe "#inspect" do
     it "only displays the sanitizer class" do
-      expect(saver.inspect).to include("@sanitizer=Terminus::Sanitizer")
+      expect(creator.inspect).to include("@sanitizer=Terminus::Sanitizer")
     end
   end
 end

--- a/spec/app/aspects/screens/creators/preprocessed_spec.rb
+++ b/spec/app/aspects/screens/creators/preprocessed_spec.rb
@@ -3,7 +3,7 @@
 require "hanami_helper"
 
 RSpec.describe Terminus::Aspects::Screens::Creators::Preprocessed, :db do
-  subject(:saver) { described_class.new }
+  subject(:creator) { described_class.new }
 
   describe "#call" do
     let :payload do
@@ -18,7 +18,7 @@ RSpec.describe Terminus::Aspects::Screens::Creators::Preprocessed, :db do
     let(:model) { Factory[:model] }
 
     it "answers screen" do
-      result = saver.call payload
+      result = creator.call payload
 
       expect(result.success).to have_attributes(
         model_id: model.id,
@@ -37,7 +37,7 @@ RSpec.describe Terminus::Aspects::Screens::Creators::Preprocessed, :db do
     end
 
     it "answers failure with database error" do
-      result = saver.call payload.with(name: nil)
+      result = creator.call payload.with(name: nil)
       expect(result.failure).to match(/null value/)
     end
   end

--- a/spec/app/aspects/screens/creators/temp_path_spec.rb
+++ b/spec/app/aspects/screens/creators/temp_path_spec.rb
@@ -3,7 +3,7 @@
 require "hanami_helper"
 
 RSpec.describe Terminus::Aspects::Screens::Creators::TempPath, :db do
-  subject(:saver) { described_class.new }
+  subject(:creator) { described_class.new }
 
   describe "#call" do
     let(:model) { Factory[:model] }
@@ -30,23 +30,23 @@ RSpec.describe Terminus::Aspects::Screens::Creators::TempPath, :db do
     end
 
     it "answers path with specific name and extension (without block)" do
-      expect(saver.call(payload).to_s).to match(%r(/test\.png))
+      expect(creator.call(payload).to_s).to match(%r(/test\.png))
     end
 
     it "answers pathname (without block)" do
-      expect(saver.call(payload)).to match(kind_of(Pathname))
+      expect(creator.call(payload)).to match(kind_of(Pathname))
     end
 
     it "answers path with specific name and extension (with block)" do
       capture = nil
-      saver.call(payload) { capture = it.to_s }
+      creator.call(payload) { capture = it.to_s }
 
       expect(capture).to match(%r(/test\.png))
     end
 
     it "answers pathname (with block)" do
       capture = nil
-      saver.call(payload) { capture = it }
+      creator.call(payload) { capture = it }
 
       expect(capture).to match(kind_of(Pathname))
     end
@@ -54,7 +54,7 @@ RSpec.describe Terminus::Aspects::Screens::Creators::TempPath, :db do
 
   describe "#inspect" do
     it "only displays the sanitizer class" do
-      expect(saver.inspect).to include("@sanitizer=Terminus::Sanitizer")
+      expect(creator.inspect).to include("@sanitizer=Terminus::Sanitizer")
     end
   end
 end

--- a/spec/app/aspects/screens/creators/unprocessed_spec.rb
+++ b/spec/app/aspects/screens/creators/unprocessed_spec.rb
@@ -3,7 +3,7 @@
 require "hanami_helper"
 
 RSpec.describe Terminus::Aspects::Screens::Creators::Unprocessed, :db do
-  subject(:saver) { described_class.new }
+  subject(:creator) { described_class.new }
 
   describe "#call" do
     let :payload do
@@ -18,7 +18,7 @@ RSpec.describe Terminus::Aspects::Screens::Creators::Unprocessed, :db do
     let(:model) { Factory[:model] }
 
     it "answers screen" do
-      result = saver.call payload
+      result = creator.call payload
 
       expect(result.success).to have_attributes(
         model_id: model.id,
@@ -37,7 +37,7 @@ RSpec.describe Terminus::Aspects::Screens::Creators::Unprocessed, :db do
     end
 
     it "answers failure with database error" do
-      result = saver.call payload.with(name: nil)
+      result = creator.call payload.with(name: nil)
       expect(result.failure).to match(/null value/)
     end
   end

--- a/spec/app/relations/playlist_item_spec.rb
+++ b/spec/app/relations/playlist_item_spec.rb
@@ -6,11 +6,25 @@ RSpec.describe Terminus::Relations::PlaylistItem, :db do
   subject(:relation) { Hanami.app["relations.playlist_item"] }
 
   describe "#next_item" do
-    it "answers current item when only item" do
+    it "answers next item with only one item" do
       playlist_id = Factory[:playlist].id
       item = Factory[:playlist_item, playlist_id:, position: 1]
 
       expect(relation.next_item(playlist_id:, after: item.position)).to include(position: 1)
+    end
+
+    it "answers next item with gaps before" do
+      playlist_id = Factory[:playlist].id
+      Factory[:playlist_item, playlist_id:, position: 1]
+
+      expect(relation.next_item(playlist_id:, after: 3)).to include(position: 1)
+    end
+
+    it "answers next item with gaps after" do
+      playlist_id = Factory[:playlist].id
+      Factory[:playlist_item, playlist_id:, position: 3]
+
+      expect(relation.next_item(playlist_id:, after: 1)).to include(position: 3)
     end
 
     it "answers next item when not at last position" do

--- a/spec/app/repositories/playlist_spec.rb
+++ b/spec/app/repositories/playlist_spec.rb
@@ -73,4 +73,22 @@ RSpec.describe Terminus::Repositories::Playlist, :db do
       expect(repository.find_by(name: nil)).to be(nil)
     end
   end
+
+  describe "#update_current_item" do
+    it "updates current item when not set" do
+      playlist = Factory[:playlist]
+      item = Factory[:playlist_item]
+      update = repository.update_current_item playlist.id, item.id
+
+      expect(update).to have_attributes(current_item_id: item.id)
+    end
+
+    it "doesn't update current item when set" do
+      item = Factory[:playlist_item]
+      playlist = Factory[:playlist, current_item_id: item.id]
+      update = repository.update_current_item playlist.id, 666
+
+      expect(update.current_item_id).to eq(item.id)
+    end
+  end
 end


### PR DESCRIPTION
## Overview

Necessary to ensure that when you create a a playlist and add an item to it that you you can immediately see the first item in that playlist. This also ensures that the next playlist item is properly calculated when there are gaps in the sequence (and will loop around to the beginning as well).

## Details

- See commits for details.
- Resolves Issue #195.