### PR TITLE
Fixed global environment setup to support multiple platforms

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -23,7 +23,7 @@ create_global_environment() {
 
   printf "%s\n" "Creating .env..."
   cp "$template_path" "$output_path"
-  sed -i '' "s|<password>|$password|g" "$output_path"
+  sed -i.tmp "s|<password>|$password|g" "$output_path" && rm "$output_path.tmp"
 }
 
 # Label: Create Development Environment


### PR DESCRIPTION
## Overview

Necessary to ensure this script works on macOS, Windows (WSL), Linux, etc. by removing the `-i ''` option which only works on macOS. This is done by using a temporary file and then removing it.

## Details

- Resolves #205.
