### PR TITLE
Added error screens for catchable errors

### DIFF
--- a/app/aspects/screens/gaffer.rb
+++ b/app/aspects/screens/gaffer.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "dry/monads"
+require "initable"
+
+module Terminus
+  module Aspects
+    module Screens
+      # Creates error with problem details for device.
+      # :reek:DataClump
+      class Gaffer
+        include Deps[
+          "aspects.screens.creator",
+          "aspects.screens.creators.temp_path",
+          repository: "repositories.screen",
+          model_repository: "repositories.model",
+          view: "views.gaffe.new"
+        ]
+        include Initable[payload: Creators::Payload]
+        include Dry::Monads[:result]
+
+        def call device, message
+          repository.find_by(name: device.system_name("error"))
+                    .then do |screen|
+                      screen ? update(screen, device, message) : create(device, message)
+                    end
+        end
+
+        def create device, message
+          creator.call content: String.new(view.call(message:)),
+                       **device.system_screen_attributes("error")
+        end
+
+        def update screen, device, message
+          screen.image_destroy
+
+          temp_path.call build_payload(device, message) do |path|
+            screen.upload StringIO.new(path.read),
+                          metadata: {"filename" => "#{device.system_name :error}.png"}
+
+            Success repository.update(screen.id, image_data: screen.image_attributes)
+          end
+        end
+
+        # :reek:FeatureEnvy
+        def build_payload device, message
+          payload[
+            model: model_repository.find(device.model_id),
+            label: device.system_label("Error"),
+            name: device.system_name("error"),
+            content: String.new(view.call(message:))
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/aspects/screens/sleeper.rb
+++ b/app/aspects/screens/sleeper.rb
@@ -15,20 +15,15 @@ module Terminus
         include Dry::Monads[:result]
 
         def call device
-          id = device.friendly_id
-          name = "terminus_sleep_#{id.downcase}"
-
-          repository.find_by(name:)
-                    .then { |screen| screen ? Success(screen) : create(id, name, device) }
+          repository.find_by(name: device.system_name("sleep"))
+                    .then { |screen| screen ? Success(screen) : create(device) }
         end
 
         private
 
-        def create id, name, device
-          creator.call model_id: device.model_id,
-                       name:,
-                       label: "Sleep #{id}",
-                       content: String.new(view.call(device:))
+        def create device
+          creator.call content: String.new(view.call(device:)),
+                       **device.system_screen_attributes("sleep")
         end
       end
     end

--- a/app/aspects/screens/welcomer.rb
+++ b/app/aspects/screens/welcomer.rb
@@ -8,12 +8,8 @@ module Terminus
         include Deps["aspects.screens.creator", view: "views.welcome.new"]
 
         def call device
-          id = device.friendly_id
-
-          creator.call model_id: device.model_id,
-                       name: "terminus_welcome_#{id.downcase}",
-                       label: "Welcome #{id}",
-                       content: String.new(view.call(device:))
+          creator.call content: String.new(view.call(device:)),
+                       **device.system_screen_attributes("welcome")
         end
       end
     end

--- a/app/structs/device.rb
+++ b/app/structs/device.rb
@@ -10,16 +10,28 @@ module Terminus
         {image_url_timeout: image_timeout, refresh_rate:, update_firmware: firmware_update}
       end
 
+      def asleep? now = Time.now
+        return false unless sleep_start_at && sleep_stop_at
+
+        (sleep_start_at.to_s..sleep_stop_at.to_s).cover? now.strftime("%H:%M:%S")
+      end
+
       def slug
         return Dry::Core::EMPTY_STRING unless mac_address
 
         mac_address.tr ":", Dry::Core::EMPTY_STRING
       end
 
-      def asleep? now = Time.now
-        return false unless sleep_start_at && sleep_stop_at
+      def system_label(prefix) = "#{prefix} #{friendly_id}"
 
-        (sleep_start_at.to_s..sleep_stop_at.to_s).cover? now.strftime("%H:%M:%S")
+      def system_name(kind) = "terminus_#{kind}_#{friendly_id.downcase}"
+
+      def system_screen_attributes kind
+        {
+          model_id:,
+          name: system_name(kind),
+          label: system_label(kind.capitalize)
+        }
       end
     end
   end

--- a/app/templates/gaffe/new.html.erb
+++ b/app/templates/gaffe/new.html.erb
@@ -1,0 +1,7 @@
+<div class="panel">
+  <p><span class="icon">💥</span></p>
+
+  <h1 class="label">Display Error!</h1>
+
+  <p class="message"><%= message %></p>
+</div>

--- a/app/templates/layouts/gaffe.html.erb
+++ b/app/templates/layouts/gaffe.html.erb
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+    <meta charset="utf-8">
+
+    <style type="text/css">
+      * {
+        margin: 0;
+      }
+
+      :where(html) {
+        font-family: Verdana;
+      }
+
+      :where(main) {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        justify-content: center;
+      }
+
+      .panel {
+        align-items: center;
+        border: 1.5rem solid red;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        justify-content: center;
+        width: 100%;
+      }
+
+      .icon {
+        font-size: 10rem;
+      }
+
+      .message {
+        font-size: 1.3rem;
+        margin: 1rem 2rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <main>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/app/views/gaffe/new.rb
+++ b/app/views/gaffe/new.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Views
+    module Gaffe
+      # The new view.
+      class New < Terminus::View
+        config.layout = "gaffe"
+
+        expose :message, decorate: false
+      end
+    end
+  end
+end

--- a/spec/app/aspects/screens/gaffer_spec.rb
+++ b/spec/app/aspects/screens/gaffer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Aspects::Screens::Gaffer, :db do
+  subject(:gaffer) { described_class.new }
+
+  describe "#call" do
+    let(:device) { Factory[:device, friendly_id: "ABC123"] }
+    let(:message) { "Danger!" }
+
+    it "creates screen" do
+      expect(gaffer.call(device, message).success).to have_attributes(
+        label: "Error ABC123",
+        name: "terminus_error_abc123",
+        image_attributes: hash_including(
+          metadata: hash_including(
+            filename: "terminus_error_abc123.png",
+            mime_type: "image/png",
+            width: 800,
+            height: 480
+          )
+        )
+      )
+    end
+
+    it "updates screen" do
+      Factory[:screen, label: "Error ABC123", name: "terminus_error_abc123"]
+
+      expect(gaffer.call(device, message).success).to have_attributes(
+        label: "Error ABC123",
+        name: "terminus_error_abc123",
+        image_attributes: hash_including(
+          metadata: hash_including(
+            filename: "terminus_error_abc123.png",
+            mime_type: "image/png",
+            width: 800,
+            height: 480
+          )
+        )
+      )
+    end
+  end
+end

--- a/spec/app/structs/device_spec.rb
+++ b/spec/app/structs/device_spec.rb
@@ -17,17 +17,6 @@ RSpec.describe Terminus::Structs::Device, :db do
     end
   end
 
-  describe "#slug" do
-    it "answers string with no colons" do
-      expect(device.slug).to eq("AABBCC112233")
-    end
-
-    it "answers empty string when slug is nil" do
-      device = Factory[:device, mac_address: nil]
-      expect(device.slug).to eq("")
-    end
-  end
-
   describe "#asleep?" do
     subject :device do
       Factory[
@@ -47,6 +36,39 @@ RSpec.describe Terminus::Structs::Device, :db do
 
     it "answers false when start and end are nil" do
       expect(Factory[:device].asleep?).to be(false)
+    end
+  end
+
+  describe "#slug" do
+    it "answers string with no colons" do
+      expect(device.slug).to eq("AABBCC112233")
+    end
+
+    it "answers empty string when slug is nil" do
+      device = Factory[:device, mac_address: nil]
+      expect(device.slug).to eq("")
+    end
+  end
+
+  describe "#system_label" do
+    it "answers system label with prefix" do
+      expect(device.system_label("Test")).to eq("Test ABC123")
+    end
+  end
+
+  describe "#system_name" do
+    it "answers system name with kind" do
+      expect(device.system_name("test")).to eq("terminus_test_abc123")
+    end
+  end
+
+  describe "#system_screen_attributes" do
+    it "answers system screen attributes" do
+      expect(device.system_screen_attributes("test")).to eq(
+        model_id: device.model_id,
+        label: "Test ABC123",
+        name: "terminus_test_abc123"
+      )
     end
   end
 end


### PR DESCRIPTION
## Overview

Necessary to provide immediate feedback for folks with actionable information for errors that can be clearly communicated to the user.

## Screenshots/Screencasts

You'll get an update screen based on error but here's an example of a screen error when you have a device with a playlist that has no items:

<img width="800" height="480" alt="example" src="https://github.com/user-attachments/assets/c6621c58-9996-4b3e-bfd1-3907debe11b6" />

The above goes away once you correct the error and wait for your device to update or short press the back of your device.

## Details

- Resolves #191 