### PR TITLE
Fixed titles for htmx fragments

### DIFF
--- a/app/templates/dashboard/show.html.erb
+++ b/app/templates/dashboard/show.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Dashboard" %>
+<%= render "shared/title", text: "Dashboard" %>
 
 <section class="page-dashboard">
   <header class="page-header">

--- a/app/templates/designer/show.html.erb
+++ b/app/templates/designer/show.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Designer" %>
+<%= render "shared/title", text: "Designer" %>
 
 <section class="page-designer">
   <header class="page-header">

--- a/app/templates/devices/edit.html.erb
+++ b/app/templates/devices/edit.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Edit #{device.label} Device" %>
+<%= render "shared/title", text: "Edit #{device.label} Device" %>
 
 <section class="page-devices">
   <header class="page-header">

--- a/app/templates/devices/index.html.erb
+++ b/app/templates/devices/index.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Devices" %>
+<%= render "shared/title", text: "Devices" %>
 
 <section class="page-devices">
   <header class="page-header">

--- a/app/templates/devices/logs/index.html.erb
+++ b/app/templates/devices/logs/index.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "#{device.label} Logs" %>
+<%= render "shared/title", text: "#{device.label} Logs" %>
 
 <section class="page-devices">
   <header class="page-header">

--- a/app/templates/devices/logs/show.html.erb
+++ b/app/templates/devices/logs/show.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "#{device.label} Log #{log.id}" %>
+<%= render "shared/title", text: "#{device.label} Log #{log.id}" %>
 
 <section class="page-devices">
   <header class="page-header">

--- a/app/templates/devices/new.html.erb
+++ b/app/templates/devices/new.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "New Device" %>
+<%= render "shared/title", text: "New Device" %>
 
 <section class="page-devices">
   <header class="page-header">

--- a/app/templates/devices/show.html.erb
+++ b/app/templates/devices/show.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "#{device.label} Device" %>
+<%= render "shared/title", text: "#{device.label} Device" %>
 
 <section class="page-devices">
   <header class="page-header">

--- a/app/templates/firmware/index.html.erb
+++ b/app/templates/firmware/index.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Firmware" %>
+<%= render "shared/title", text: "Firmware" %>
 
 <section class="page-firmware">
   <header class="page-header">

--- a/app/templates/playlists/_item.html.erb
+++ b/app/templates/playlists/_item.html.erb
@@ -1,4 +1,10 @@
 <div class="show_item">
-  <img src="<%= item.screen.image_uri %>" class="image" loading="lazy" width="100" height="60">
+  <img src="<%= item.screen.image_uri %>"
+       alt="Screen"
+       class="image"
+       loading="lazy"
+       width="100"
+       height="60">
+
   <%= link_to item.screen.label, routes.path(:screen, id: item.screen.id) %>
 </div>

--- a/app/templates/playlists/edit.html.erb
+++ b/app/templates/playlists/edit.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Edit #{playlist.label} Playlist" %>
+<%= render "shared/title", text: "Edit #{playlist.label} Playlist" %>
 
 <section class="page-playlists">
   <header class="page-header">

--- a/app/templates/playlists/index.html.erb
+++ b/app/templates/playlists/index.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Playlists" %>
+<%= render "shared/title", text: "Playlists" %>
 
 <section class="page-playlists">
   <header class="page-header">

--- a/app/templates/playlists/items/_item.html.erb
+++ b/app/templates/playlists/items/_item.html.erb
@@ -2,7 +2,12 @@
 <% delete_uri = routes.path :playlist_item_delete, playlist_id: item.playlist_id, id: item.id %>
 
 <div class="item">
-  <img src="<%= item.screen.image_uri %>" class="image" loading="lazy" width="200" height="120">
+  <img src="<%= item.screen.image_uri %>"
+       alt="Screen"
+       class="image"
+       loading="lazy"
+       width="200"
+       height="120">
 
   <div class="actions">
     <a href="<%= edit_uri %>"

--- a/app/templates/playlists/mirror/edit.html.erb
+++ b/app/templates/playlists/mirror/edit.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Mirror #{playlist.label} Playlist" %>
+<%= render "shared/title", text: "Mirror #{playlist.label} Playlist" %>
 
 <section class="page-playlists">
   <header class="page-header">

--- a/app/templates/playlists/new.html.erb
+++ b/app/templates/playlists/new.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "New Playlist" %>
+<%= render "shared/title", text: "New Playlist" %>
 
 <section class="page-playlists">
   <header class="page-header">

--- a/app/templates/playlists/show.html.erb
+++ b/app/templates/playlists/show.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "#{playlist.label} Playlist" %>
+<%= render "shared/title", text: "#{playlist.label} Playlist" %>
 
 <section class="page-playlists">
   <header class="page-header">

--- a/app/templates/problem_details/index.html.erb
+++ b/app/templates/problem_details/index.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Problem Details" %>
+<%= render "shared/title", text: "Problem Details" %>
 
 <section class="page-problem_details">
   <header class="page-header">

--- a/app/templates/screens/_screen.html.erb
+++ b/app/templates/screens/_screen.html.erb
@@ -1,5 +1,10 @@
 <li id="<%= screen.id %>" class="screen">
-   <%= tag.img src: screen.image_uri, class: :image, width: 250, height: 150, loading: :lazy %>
+   <%= tag.img src: screen.image_uri,
+               alt: "Screen",
+               class: :image,
+               width: 250,
+               height: 150,
+               loading: :lazy %>
 
   <h2 class="label"><%= screen.label %></h2>
 

--- a/app/templates/screens/edit.html.erb
+++ b/app/templates/screens/edit.html.erb
@@ -19,7 +19,12 @@
 
         <h1 class="label">Edit Screen</h1>
 
-        <img src="<%= screen.image_uri %>" class="image" loading="lazy" width="200" height="120">
+        <img src="<%= screen.image_uri %>"
+             alt="Screen"
+             class="image"
+             width="200"
+             height="120"
+             loading="lazy">
 
         <%= render :fields, models:, screen:, fields: fields.value, errors: %>
 

--- a/app/templates/screens/edit.html.erb
+++ b/app/templates/screens/edit.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Edit #{screen.label} Screen" %>
+<%= render "shared/title", text: "Edit #{screen.label} Screen" %>
 
 <section class="page-screens">
   <header class="page-header">

--- a/app/templates/screens/index.html.erb
+++ b/app/templates/screens/index.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "Screens" %>
+<%= render "shared/title", text: "Screens" %>
 
 <section class="page-screens">
   <header class="page-header">

--- a/app/templates/screens/new.html.erb
+++ b/app/templates/screens/new.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "New Screen" %>
+<%= render "shared/title", text: "New Screen" %>
 
 <section class="page-screens">
   <header class="page-header">

--- a/app/templates/screens/show.html.erb
+++ b/app/templates/screens/show.html.erb
@@ -1,4 +1,4 @@
-<% render "shared/title", text: "#{screen.label} Screen" %>
+<%= render "shared/title", text: "#{screen.label} Screen" %>
 
 <section class="page-screens">
   <header class="page-header">

--- a/app/templates/screens/show.html.erb
+++ b/app/templates/screens/show.html.erb
@@ -10,7 +10,12 @@
 
   <div class="page-body">
     <div class="screen">
-      <%= tag.img src: screen.image_uri, class: :image, width: 250, height: 150, loading: :lazy %>
+      <%= tag.img src: screen.image_uri,
+                  alt: "Screen",
+                  class: :image,
+                  width: 250,
+                  height: 150,
+                  loading: :lazy %>
 
       <h2 class="label"><%= screen.label %></h2>
 

--- a/app/templates/shared/_title.html.erb
+++ b/app/templates/shared/_title.html.erb
@@ -1,1 +1,4 @@
-<% content_for :title, "#{text} | Terminus" %>
+<% content = "#{text} | Terminus" %>
+
+<% content_for :title, content %>
+<%= tag.title content if htmx? %>

--- a/app/views/context.rb
+++ b/app/views/context.rb
@@ -1,0 +1,15 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "hanami/view"
+
+module Terminus
+  module Views
+    # The application custom view context.
+    class Context < Hanami::View::Context
+      include Deps[:htmx]
+
+      def htmx? = htmx.request? request.env, :request, "true"
+    end
+  end
+end

--- a/spec/app/actions/devices/create_spec.rb
+++ b/spec/app/actions/devices/create_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Terminus::Actions::Devices::Create, :db do
 
     it "renders htmx response" do
       response = Rack::MockRequest.new(action).post("", "HTTP_HX_REQUEST" => "true", params:)
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title("Devices")
     end
   end
 end

--- a/spec/app/actions/devices/edit_spec.rb
+++ b/spec/app/actions/devices/edit_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Terminus::Actions::Devices::Edit, :db do
       response = Rack::MockRequest.new(action)
                                   .get "", "HTTP_HX_REQUEST" => "true", params: {id: device.id}
 
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title("Edit Test Device")
     end
 
     it "answers errors with invalid parameters" do

--- a/spec/app/actions/devices/new_spec.rb
+++ b/spec/app/actions/devices/new_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Terminus::Actions::Devices::New do
 
     it "renders htmx response" do
       response = Rack::MockRequest.new(action).post("", "HTTP_HX_REQUEST" => "true", params:)
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title("New Device")
     end
   end
 end

--- a/spec/app/actions/devices/show_spec.rb
+++ b/spec/app/actions/devices/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Terminus::Actions::Devices::Show, :db do
       response = Rack::MockRequest.new(action)
                                   .get "", "HTTP_HX_REQUEST" => "true", params: {id: device.id}
 
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title("Test Device")
     end
 
     it "answers unprocessable entity with invalid parameters" do

--- a/spec/app/actions/playlists/create_spec.rb
+++ b/spec/app/actions/playlists/create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Terminus::Actions::Playlists::Create, :db do
 
     it "renders htmx response" do
       response = Rack::MockRequest.new(action).post("", "HTTP_HX_REQUEST" => "true", params:)
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title("Playlists")
     end
   end
 end

--- a/spec/app/actions/playlists/edit_spec.rb
+++ b/spec/app/actions/playlists/edit_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Terminus::Actions::Playlists::Edit, :db do
       response = Rack::MockRequest.new(action)
                                   .get "", "HTTP_HX_REQUEST" => "true", params: {id: playlist.id}
 
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title(/Edit Playlist \d+ Playlist/)
     end
 
     it "answers errors with invalid parameters" do

--- a/spec/app/actions/playlists/mirror/edit_spec.rb
+++ b/spec/app/actions/playlists/mirror/edit_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Terminus::Actions::Playlists::Mirror::Edit, :db do
       response = Rack::MockRequest.new(action)
                                   .get "", "HTTP_HX_REQUEST" => "true", params: {id: playlist.id}
 
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title(/Mirror Playlist \d+ Playlist/)
     end
 
     it "answers errors with invalid parameters" do

--- a/spec/app/actions/playlists/mirror/update_spec.rb
+++ b/spec/app/actions/playlists/mirror/update_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Terminus::Actions::Playlists::Mirror::Update, :db do
       end
 
       it "renders htmx response" do
-        expect(response.body).not_to include("<!DOCTYPE html>")
+        expect(response.body).to have_htmx_title(/Playlist \d+ Playlist/)
       end
     end
   end

--- a/spec/app/actions/playlists/new_spec.rb
+++ b/spec/app/actions/playlists/new_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Terminus::Actions::Playlists::New do
 
     it "renders htmx response" do
       response = Rack::MockRequest.new(action).post("", "HTTP_HX_REQUEST" => "true", params:)
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title("New Playlist")
     end
   end
 end

--- a/spec/app/actions/playlists/show_spec.rb
+++ b/spec/app/actions/playlists/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Terminus::Actions::Playlists::Show, :db do
       response = Rack::MockRequest.new(action)
                                   .get "", "HTTP_HX_REQUEST" => "true", params: {id: playlist.id}
 
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title(/Playlist \d+ Playlist/)
     end
 
     it "answers unprocessable entity with invalid parameters" do

--- a/spec/app/actions/screens/create_spec.rb
+++ b/spec/app/actions/screens/create_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Terminus::Actions::Screens::Create, :db do
 
     it "renders htmx response" do
       response = Rack::MockRequest.new(action).post("", "HTTP_HX_REQUEST" => "true", params:)
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title("Screens")
     end
   end
 end

--- a/spec/app/actions/screens/edit_spec.rb
+++ b/spec/app/actions/screens/edit_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Terminus::Actions::Screens::Edit, :db do
       response = Rack::MockRequest.new(action)
                                   .get "", "HTTP_HX_REQUEST" => "true", params: {id: screen.id}
 
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title(/Edit Screen \d+ Screen/)
     end
 
     it "answers errors with invalid parameters" do

--- a/spec/app/actions/screens/new_spec.rb
+++ b/spec/app/actions/screens/new_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Terminus::Actions::Screens::New, :db do
 
     it "renders htmx response" do
       response = Rack::MockRequest.new(action).post("", "HTTP_HX_REQUEST" => "true", params:)
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title("New Screen")
     end
   end
 end

--- a/spec/app/actions/screens/show_spec.rb
+++ b/spec/app/actions/screens/show_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Terminus::Actions::Screens::Show, :db do
       response = Rack::MockRequest.new(action)
                                   .get "", "HTTP_HX_REQUEST" => "true", params: {id: screen.id}
 
-      expect(response.body).not_to include("<!DOCTYPE html>")
+      expect(response.body).to have_htmx_title(/Screen \d+ Screen/)
     end
 
     it "answers unprocessable entity with invalid parameters" do

--- a/spec/app/views/context_spec.rb
+++ b/spec/app/views/context_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Views::Context do
+  subject(:a_context) { described_class.new }
+
+  describe "#htmx?" do
+    it "answers true when htmx request" do
+      request = Hanami::Action::Request.new env: {"HTTP_HX_REQUEST" => "true"}, params: {}
+      a_context.instance_variable_set :@request, request
+
+      expect(a_context.htmx?).to be(true)
+    end
+
+    it "answers false when not a htmx HTTP request" do
+      request = Hanami::Action::Request.new env: {}, params: {}
+      a_context.instance_variable_set :@request, request
+
+      expect(a_context.htmx?).to be(false)
+    end
+  end
+end

--- a/spec/support/matchers/have_htmx_title.rb
+++ b/spec/support/matchers/have_htmx_title.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_htmx_title do |text|
+  match { |actual| actual.start_with? %r(\n<title>#{text} | Terminus</title>) }
+end


### PR DESCRIPTION
## Overview

Necessary to ensure the page title is updated when using htmx fragments.

## Details

- Resolves #209 
- See commits for details.