### PR TITLE
Fix setup endpoint docs

### DIFF
--- a/doc/api.adoc
+++ b/doc/api.adoc
@@ -168,7 +168,8 @@ curl "https://localhost:2443/api/setup/" \
   "api_key": "<redacted>",
   "friendly_id": "ABC123",
   "image_url": "https://localhost:2443/assets/setup.bmp",
-  "message": "Welcome to TRMNL BYOS"
+  "message": "Welcome to TRMNL BYOS",
+  "status": 200
 }
 ----
 ====


### PR DESCRIPTION
The currently documented endpoint fails to deserialize on firmware 1.6.5+. This change correctly documents the expected structure

## Overview
<!-- Required. Describe, briefly, why this is necessary and what the overarching architecture is. -->

## Screenshots/Screencasts
<!-- Optional. Provide supporting screen shots/casts. -->

## Details
<!-- Optional. As bullet points, list related issue(s); major highlights; team callouts; and/or other information that is helpful. -->
