### PR TITLE
Improve compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,9 @@ RUN <<STEPS
 STEPS
 
 FROM base
+
+ENV HANAMI_PORT=2300
+
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /app /app
 

--- a/compose.yml
+++ b/compose.yml
@@ -5,13 +5,13 @@ services:
     init: true
     image: ghcr.io/usetrmnl/terminus:latest
     environment:
-      HANAMI_PORT: ${HANAMI_PORT}
-      API_URI: ${API_URI}
-      APP_SECRET: ${APP_SECRET}
-      DATABASE_URL: postgres://${PG_USER}:${PG_PASSWORD}@database:${PG_PORT}/${PG_DATABASE}
-      REDIS_URL: redis://:${REDIS_PASSWORD}@cache:${REDIS_PORT}/${REDIS_DATABASE}
+      API_URI: ${API_URI:?}
+      APP_SECRET: ${APP_SECRET:?}
+      DATABASE_URL: postgres://${PG_USER:-terminus}:${PG_PASSWORD:?}@database:${PG_PORT:-5432}/${PG_DATABASE:-terminus}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?}@cache:${REDIS_PORT:-6379}/${REDIS_DATABASE:-0}
+      LOG_LEVEL: ${WEB_LOG_LEVEL:-info}
     ports:
-      - "${HANAMI_PORT}:${HANAMI_PORT}"
+      - "${WEB_PORT:-2300}:2300"
     restart: unless-stopped
     volumes:
       - web-uploads:/app/public/uploads
@@ -25,13 +25,27 @@ services:
         limits:
           memory: 1G
           cpus: "1.0"
+    healthcheck:
+      test: [
+        "CMD",
+        "curl",
+        "--fail",
+        "--silent",
+        "http://localhost:2300"
+      ]
+      interval: 5m
+      retries: 3
+      start_period: 1m
+      timeout: 5s
 
   worker:
     image: ghcr.io/usetrmnl/terminus:latest
     environment:
-      APP_SECRET: ${APP_SECRET}
-      DATABASE_URL: postgres://${PG_USER}:${PG_PASSWORD}@database:${PG_PORT}/${PG_DATABASE}
-      REDIS_URL: redis://:${REDIS_PASSWORD}@cache:${REDIS_PORT}/${REDIS_DATABASE}
+      API_URI: ${API_URI:?}
+      APP_SECRET: ${APP_SECRET:?}
+      DATABASE_URL: postgres://${PG_USER:-terminus}:${PG_PASSWORD:?}@database:${PG_PORT:-5432}/${PG_DATABASE:-terminus}
+      REDIS_URL: redis://${REDIS_PASSWORD:?}@cache:${REDIS_PORT:-6379}/${REDIS_DATABASE:-0}
+      LOG_LEVEL: ${WORKER_LOG_LEVEL:-warn}
     command: bundle exec sidekiq -r ./config/sidekiq.rb
     depends_on:
       database:
@@ -42,16 +56,16 @@ services:
   database:
     image: postgres:18.0
     environment:
-      POSTGRES_USER: ${PG_USER}
-      POSTGRES_DB: ${PG_DATABASE}
-      POSTGRES_PASSWORD: ${PG_PASSWORD}
+      POSTGRES_USER: ${PG_USER:-terminus}
+      POSTGRES_DB: ${PG_DATABASE:-terminus}
+      POSTGRES_PASSWORD: ${PG_PASSWORD:?}
     ports:
-      - "${PG_PORT}:${PG_PORT}"
+      - "${PG_PORT:-5432}:5432"
     volumes:
       - database-data:/var/lib/postgresql
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${PG_USER} -d ${PG_DATABASE}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB} -q"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -63,13 +77,15 @@ services:
 
   cache:
     image: redis:8-alpine
+    environment:
+      REDISCLI_AUTH: ${REDIS_PASSWORD:?}
     ports:
-      - "${REDIS_PORT}:${REDIS_PORT}"
-    command: redis-server --requirepass ${REDIS_PASSWORD}
+      - "${REDIS_PORT:-6379}:6379"
+    command: redis-server --requirepass ${REDIS_PASSWORD:?}
     volumes:
       - cache-data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "--pass", "${REDIS_PASSWORD}", "ping"]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 1s
       timeout: 2s
       retries: 5


### PR DESCRIPTION
Hi there,

this PR will improve various issues in the docker-compose configuration:

* The compose-file should always provide sane defaults; which _can_ be changed, but don't _have to be_ changed.  
This will greatly simplify things for anyone who quickly wants to try out "byos_hanami" (without having to figure out the various settings for ports, database-names, etc.).  
Using the current `compose.yml` will show this:
```
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"HANAMI_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"HANAMI_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"APP_SECRET\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_USER\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_PASSWORD\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_DATABASE\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_PASSWORD\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_DATABASE\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"HANAMI_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"API_URI\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"APP_SECRET\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_USER\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_PASSWORD\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_DATABASE\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_PASSWORD\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_DATABASE\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_USER\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_DATABASE\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_PASSWORD\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_USER\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"PG_DATABASE\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_PORT\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_PASSWORD\" variable is not set. Defaulting to a blank string."
time="2025-11-16T10:55:05+01:00" level=warning msg="The \"REDIS_PASSWORD\" variable is not set. Defaulting to a blank string."
```
A lot of warnings about unset variables (defaulting to a "blank string").
And the containers will - of course - not start up as expected.

* There also should be a clear distinction between mandatory and optional (env-)settings.  
It's best practice to use interpolation for this; see: [compose-file interpolation](https://docs.docker.com/reference/compose-file/interpolation/)  
This will slim down the minimal necessary `.env` file to this:
```
API_URI=http://localhost:2300
APP_SECRET=***
REDIS_PASSWORD=***
PG_PASSWORD=***
```
Another benefit: `docker-compose` will check for all mandatory env-vars **before** even trying to start up any containers.

* The log-level for the worker-container has to be reduced to `warn`; otherwise the Redis-password will be leaked:  
```
...
worker-1    | {"id":"terminus","level":"INFO","at":"2025-11-16T09:52:09.129+00:00","message":"Upgrade to Sidekiq Pro for more features and support: https://sidekiq.org"}
worker-1    | {"id":"terminus","level":"INFO","at":"2025-11-16T09:52:09.129+00:00","message":"Sidekiq 7.3.9 connecting to Redis with options {size: 10, pool_name: \"internal\", url: \"redis://myRedisPassword@cache:6379/0\"}"}
worker-1    | {"id":"terminus","level":"INFO","at":"2025-11-16T09:52:09.137+00:00","message":"Sidekiq 7.3.9 connecting to Redis with options {size: 5, pool_name: \"default\", url: \"redis://myRedisPassword@cache:6379/0\"}"}
worker-1    | {"id":"trmnl-api","level":"INFO","at":"2025-11-16T09:52:08.940+00:00","message":"> GET https://usetrmnl.com/api/models"}
...
```

* The "cache"-healthcheck needs to be improved:  
"NOTE: For security reasons, provide the password to redis-cli automatically via the REDISCLI_AUTH environment variable." [redis-cli](https://redis.io/docs/latest/develop/tools/cli/)

Thanks. :bow:
