### PR TITLE
Use init for worker

### DIFF
--- a/.config/setup/compose.dev.yml.tt
+++ b/.config/setup/compose.dev.yml.tt
@@ -38,6 +38,7 @@ services:
           cpus: "1.0"
 
   worker:
+    init: true
     build:
       context: .
       target: development

--- a/compose.yml
+++ b/compose.yml
@@ -33,6 +33,7 @@ services:
           cpus: "1.0"
 
   worker:
+    init: true
     image: ghcr.io/usetrmnl/terminus:latest
     environment:
       HANAMI_PORT: ${HANAMI_PORT}


### PR DESCRIPTION
Needed an init to clean up processes generated in extension worker.

## Overview
I've been working on my private extension. After running it for a while, I noticed many defunct processes in the worker container. Adding `init: true` resolved the problem for me.

## Screenshots/Screencasts
Unfortunately I did not capture any screenshots. I'm working back through the small changes I made to create PRs, and this was just the first most trivial change to submit.

## Details
<!-- Optional. As bullet points, list related issue(s); major highlights; team callouts; and/or other information that is helpful. -->
