### PR TITLE
Added liquid json filter

### DIFF
--- a/app/aspects/liquid/filters.rb
+++ b/app/aspects/liquid/filters.rb
@@ -1,0 +1,14 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "json"
+
+module Terminus
+  module Aspects
+    module Liquid
+      module Filters
+        def json(data) = JSON.generate data
+      end
+    end
+  end
+end

--- a/config/providers/liquid.rb
+++ b/config/providers/liquid.rb
@@ -4,7 +4,10 @@ Hanami.app.register_provider :liquid, namespace: true do
   prepare { require "liquid" }
 
   start do
-    default = Liquid::Environment.build { it.error_mode = :strict }
+    default = Liquid::Environment.build do |environment|
+      environment.error_mode = :strict
+      environment.register_filter Terminus::Aspects::Liquid::Filters
+    end
 
     renderer = lambda do |template, data, environment: default|
       Liquid::Template.parse(template, environment:).render data

--- a/spec/app/aspects/liquid/filters_spec.rb
+++ b/spec/app/aspects/liquid/filters_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+require "json"
+require "liquid"
+
+RSpec.describe Terminus::Aspects::Liquid::Filters do
+  subject :renderer do
+    -> template, data { Liquid::Template.parse(template, environment:).render data }
+  end
+
+  let :environment do
+    Liquid::Environment.build do |environment|
+      environment.error_mode = :strict
+      environment.register_filter described_class
+    end
+  end
+
+  describe "#json" do
+    it "answers hash as JSON" do
+      content = renderer.call "{{ data | json }}", {"data" => {"name" => "Test", "count" => 42}}
+      expect(JSON.parse(content)).to eq("name" => "Test", "count" => 42)
+    end
+
+    it "answers array as JSON" do
+      content = renderer.call "{{ items | json }}", {"items" => [{"id" => 1}, {"id" => 2}]}
+      expect(JSON.parse(content)).to eq([{"id" => 1}, {"id" => 2}])
+    end
+
+    it "answers string as JSON" do
+      content = renderer.call "{{ str | json }}", {"str" => "string value"}
+      expect(JSON.parse(content)).to eq("string value")
+    end
+
+    it "answers number as JSON" do
+      content = renderer.call "{{ num | json }}", {"num" => 42}
+      expect(JSON.parse(content)).to eq(42)
+    end
+
+    it "answers nested data" do
+      data = {
+        "user" => {
+          "name" => "Alice",
+          "roles" => %w[admin user],
+          "metadata" => {"active" => true}
+        }
+      }
+
+      content = renderer.call "{{user | json}}", data
+
+      expect(JSON(content)).to eq(
+        {
+          "name" => "Alice",
+          "roles" => %w[admin user],
+          "metadata" => {"active" => true}
+        }
+      )
+    end
+
+    it "fails when parsing invalid JSON" do
+      expectation = proc { renderer.call "{{ data | json }}", "bogus" }
+      expect(&expectation).to raise_error(Liquid::ArgumentError, /Expected Hash/)
+    end
+  end
+end


### PR DESCRIPTION
## Overview

Without an explicit json filter, it was not possible to directly pass an entire JSON object from a fetched URL to the template in an extension. The worker would die with:

```
  SyntaxError: Unexpected token '=>'
```

## Screenshots/Screencasts

Fuller stack trace of the error I got:
```
SyntaxError: Unexpected token '=>'
/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.9/lib/sidekiq/cli.rb:128:in 'IO#wait_readable'
/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.9/lib/sidekiq/cli.rb:128:in 'Sidekiq::CLI#launch'
/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.9/lib/sidekiq/cli.rb:115:in 'Sidekiq::CLI#run'
/usr/local/bundle/ruby/3.4.0/gems/sidekiq-8.0.9/bin/sidekiq:31:in '<top (required)>'
/usr/local/bundle/ruby/3.4.0/bin/sidekiq:25:in 'Kernel#load'
/usr/local/bundle/ruby/3.4.0/bin/sidekiq:25:in '<top (required)>'
```

## Details

In my dashboard extension, one of the source URLs returns a full JSON object. Within the template, I pass this entire result to a Javascript function to do some post-processing and render the result using Chart.js.

```
      <script>
        (function() {
          const teams = {{ source_1.data | json }};
          const currentHour = {{ source_2 | json }};

          renderChart("score-chart", teams, currentHour);
        })();
      </script>
```

I haven't fully investigated why JSON  array responses are wrapped in an object with a data key, and JSON object responses are passed through directly. I see where it's happening, just haven't tried to understand why. In my case, source_1 is a JSON array response, and source_2 is a JSON object response.