### PR TITLE
Added canvas to allowed elements

### DIFF
--- a/app/aspects/sanitizer.rb
+++ b/app/aspects/sanitizer.rb
@@ -22,10 +22,13 @@ module Terminus
 
       def configuration = client::Config.merge(defaults, elements:, attributes:)
 
-      def elements = defaults[:elements].including "html", "link", "script", "source", "style"
+      def elements
+        defaults[:elements].including "canvas", "html", "link", "script", "source", "style"
+      end
 
       def attributes
-        defaults[:attributes].merge "div" => [:data],
+        defaults[:attributes].merge "canvas" => %w[id width height],
+                                    "div" => [:data],
                                     "link" => %w[href rel],
                                     "script" => %w[src],
                                     "source" => %w[type src srcset sizes media height width]

--- a/spec/app/aspects/sanitizer_spec.rb
+++ b/spec/app/aspects/sanitizer_spec.rb
@@ -67,5 +67,16 @@ RSpec.describe Terminus::Aspects::Sanitizer do
 
       expect(sanitizer.call(source)).to eq(source)
     end
+
+    it "allows canvas element with id, width, and height" do
+      source = <<~HTML.squeeze(" ").delete("\n").strip
+        <html><head></head>
+          <body>
+            <canvas id="test-canvas" width="300" height="150"></canvas>
+        </body></html>
+      HTML
+
+      expect(sanitizer.call(source)).to eq(source)
+    end
   end
 end


### PR DESCRIPTION
## Overview

Allows the canvas element to pass through the sanitizer. Enables more rendering options for extensions. For instance, the [standard way to bootstrap Chart.js](https://www.chartjs.org/docs/latest/getting-started/) is to create a placeholder canvas element that you pass to the library.

## Details

I only allowed id, width, and height attributes, but am open to arguments for which other attributes might be wanted.