### PR TITLE
Fixed database migrations disabled on worker to not concurrently setup schema

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -55,6 +55,7 @@ services:
       APP_SECRET: ${APP_SECRET}
       DATABASE_URL: postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@database:${DATABASE_PORT}/${DATABASE_NAME}
       KEYVALUE_URL: redis://:${KEYVALUE_PASSWORD}@keyvalue:${KEYVALUE_PORT}/${KEYVALUE_DATABASE}
+      SKIP_MIGRATIONS: "true"
     command: bundle exec sidekiq -r ./config/sidekiq.rb
     restart: unless-stopped
     volumes:

--- a/scripts/docker/entrypoint
+++ b/scripts/docker/entrypoint
@@ -7,7 +7,7 @@ jemalloc_path = Dir["/usr/lib/*/libjemalloc.so.2"]
 ENV["LD_PRELOAD"] = jemalloc_path.first unless ENV.key?("LD_PRELOAD") || jemalloc_path.empty?
 
 system "bundle exec hanami assets compile"
-system "bundle exec hanami db migrate"
+system "bundle exec hanami db migrate" unless ENV["SKIP_MIGRATIONS"] == "true"
 
 %w[firmware screen model].each do |poller|
   pid = spawn "bin/pollers/#{poller}"


### PR DESCRIPTION
## Overview
While starting up a new instance of terminus with docker compose, I experienced some issues with web and workers trying to perform the same schema migrations on the database.
The database itself handled it gracefully, but we can avoid that with a simple `if/unless`

