### PR TITLE
Fix Types::Version to support multi-digit version numbers

### DIFF
--- a/lib/terminus/types.rb
+++ b/lib/terminus/types.rb
@@ -20,6 +20,6 @@ module Terminus
       format: /\A[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}\Z/
     )
 
-    Version = String.constrained(format: /\A[0-9]\.[0-9]\.[0-9]\Z/)
+    Version = String.constrained(format: /\A\d+\.\d+\.\d+\Z/)
   end
 end


### PR DESCRIPTION
## Overview
The `Types::Version` regex was too restrictive, only allowing single-digit version components (e.g., `1.2.3`) but rejecting versions like `1.6.10`.

## Details
This caused `/api/display` to return 404 for devices running firmware 1.6.10, while `/api/setup` worked fine (it uses `Versionaire::PATTERN` instead).

**To reproduce:**
1. Set up a device with firmware v1.6.10
2. Device connects to WiFi successfully
3. `/api/setup` returns 200, device appears in web UI
4. `/api/display` returns 404
5. Device logs show: `Error fetching API display: 7, detail: HTTP Client failed with error: (404)`

**Fix:** Changed the regex from `/\A[0-9]\.[0-9]\.[0-9]\Z/` to `/\A\d+\.\d+\.\d+\Z/`