### PR TITLE
Add to PostgreSQL config to make it work without further adjustment

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -82,6 +82,7 @@ services:
       POSTGRES_USER: ${DATABASE_USER}
       POSTGRES_DB: ${DATABASE_NAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
     ports:
       - "${DATABASE_PORT}:${DATABASE_PORT}"
     volumes:


### PR DESCRIPTION
## Overview
compose.yml currently does not start. The web container throws an error, because it cant connect to the db:
"password authentication failed for user". This is because password auth is not enabled by default in postgres 18.1


## Details
This additional option in the compose fixes the problem and make it start right away.
