### PR TITLE
Fixed screen upload form encoding and stabilize feature specs

### DIFF
--- a/app/templates/screens/new.html.erb
+++ b/app/templates/screens/new.html.erb
@@ -10,7 +10,11 @@
 
   <div class="bit-body">
     <div class="screens">
-      <%= form_for :screen, routes.path(:screens), class: "bit-card bit-form" do |form| %>
+      <%= form_for :screen,
+                   routes.path(:screens),
+                   enctype: "multipart/form-data",
+                   accept: "application/octet-stream",
+                   class: "bit-card bit-form" do |form| %>
         <h1 class="label">New Screen</h1>
 
         <%= render "screens/shared/fields", form:, models:, screen:, fields: fields.value, errors: %>

--- a/spec/features/models_spec.rb
+++ b/spec/features/models_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Models", :db do
     expect(page).to have_content("Test")
 
     click_link "Edit"
-    fill_in "model[label]", with: nil
+    fill_in "model[label]", with: ""
     click_button "Save"
 
     expect(page).to have_content("must be filled")
@@ -30,7 +30,7 @@ RSpec.describe "Models", :db do
 
     visit routes.path(:models)
     click_link "Clone"
-    fill_in "model[name]", with: nil
+    fill_in "model[name]", with: ""
     click_button "Save"
 
     expect(page).to have_content("must be filled")

--- a/spec/features/screens_spec.rb
+++ b/spec/features/screens_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Screens", :db do
     expect(page).to have_content("Test")
 
     click_link "Edit"
-    fill_in "screen[label]", with: nil
+    fill_in "screen[label]", with: ""
     click_button "Save"
 
     expect(page).to have_content("must be filled")


### PR DESCRIPTION
## Overview
<!-- Required. Describe, briefly, why this is necessary and what the overarching architecture is. -->

Ensure the new screen form submits file uploads as multipart data. Replace nil-based input clearing in feature specs with explicit empty strings for stable Capybara behavior. This addresses the failing Models and Screens JS feature tests.

## Details
<!-- Optional. As bullet points, list related issue(s); major highlights; team callouts; and/or other information that is helpful. -->

Fixes following build error from #289

Milestone: patch
