### PR TITLE
add helper button to generate mac address and API key on "device" screen

### DIFF
--- a/app/assets/images/icons/refresh.svg
+++ b/app/assets/images/icons/refresh.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800px" height="800px" viewBox="0 0 24 24" fill="none">
+  <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C14.8273 3 17.35 4.30367 19 6.34267" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M19 3V7H15" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/assets/images/icons/refresh.svg
+++ b/app/assets/images/icons/refresh.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800px" height="800px" viewBox="0 0 24 24" fill="none">
-  <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C14.8273 3 17.35 4.30367 19 6.34267" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M19 3V7H15" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/app/assets/images/icons/wand.svg
+++ b/app/assets/images/icons/wand.svg
@@ -1,0 +1,6 @@
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 21L13 11" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M13.5 6.5L17.5 10.5L21 3L13.5 6.5Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8 3L8.5 4.5L10 5L8.5 5.5L8 7L7.5 5.5L6 5L7.5 4.5L8 3Z" fill="#000000"/>
+  <path d="M19 13L19.5 14L21 14.5L19.5 15L19 16L18.5 15L17 14.5L18.5 14L19 13Z" fill="#000000"/>
+</svg>

--- a/app/assets/images/icons/wand.svg
+++ b/app/assets/images/icons/wand.svg
@@ -1,6 +1,10 @@
-<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M3 21L13 11" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M13.5 6.5L17.5 10.5L21 3L13.5 6.5Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M8 3L8.5 4.5L10 5L8.5 5.5L8 7L7.5 5.5L6 5L7.5 4.5L8 3Z" fill="#000000"/>
-  <path d="M19 13L19.5 14L21 14.5L19.5 15L19 16L18.5 15L17 14.5L18.5 14L19 13Z" fill="#000000"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="800px" height="800px" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72" />
+  <path d="m14 7 3 3" />
+  <path d="M5 6v4" />
+  <path d="M19 14v4" />
+  <path d="M10 2v2" />
+  <path d="M7 8H3" />
+  <path d="M21 16h-4" />
+  <path d="M11 3H9" />
 </svg>

--- a/app/templates/devices/shared/_fields.html.erb
+++ b/app/templates/devices/shared/_fields.html.erb
@@ -49,13 +49,24 @@
       <%= render "shared/popovers/triggers/default", name: :mac_address %>
     </label>
 
-    <div class="input-group" x-data="{ show: false }">
+    <div class="input-group" x-data="{
+      show: false,
+      generateMAC() {
+        const hex = () => [...Array(2)].map(() => Math.floor(Math.random() * 16).toString(16).toUpperCase()).join('');
+        this.$refs.mac.value = [hex(), hex(), hex(), hex(), hex(), hex()].join(':');
+      }
+    }">
       <%= form.text_field :mac_address,
                           id: :device_mac_address,
                           value: field_for(:mac_address, fields, device),
                           class: "value value-cap",
                           autocomplete: :off,
+                          "x-ref" => "mac",
                           "x-bind:type" => "show ? 'text' : 'password'"%>
+
+      <button type="button" class="action" title="Generate MAC address" x-on:click="generateMAC(); show = true">
+        <%= image_tag "icons/refresh.svg", alt: "Generate", width: 25, height: 25 %>
+      </button>
 
       <%= render "shared/visibility_button" %>
     </div>
@@ -67,13 +78,24 @@
       <%= render "shared/popovers/triggers/default", name: :api_key %>
     </label>
 
-    <div class="input-group" x-data="{ show: false }">
+    <div class="input-group" x-data="{
+      show: false,
+      generateKey() {
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        this.$refs.apikey.value = [...Array(20)].map(() => chars[Math.floor(Math.random() * chars.length)]).join('');
+      }
+    }">
       <%= form.text_field :api_key,
                           id: :device_api_key,
                           value: field_for(:api_key, fields, device),
                           class: "value value-cap",
                           autocomplete: :off,
+                          "x-ref" => "apikey",
                           "x-bind:type" => "show ? 'text' : 'password'"%>
+
+      <button type="button" class="action" title="Generate API key" x-on:click="generateKey(); show = true">
+        <%= image_tag "icons/refresh.svg", alt: "Generate", width: 25, height: 25 %>
+      </button>
 
       <%= render "shared/visibility_button" %>
     </div>

--- a/app/templates/devices/shared/_fields.html.erb
+++ b/app/templates/devices/shared/_fields.html.erb
@@ -65,7 +65,7 @@
                           "x-bind:type" => "show ? 'text' : 'password'"%>
 
       <button type="button" class="action" title="Generate MAC address" x-on:click="generateMAC(); show = true">
-        <%= image_tag "icons/refresh.svg", alt: "Generate", width: 25, height: 25 %>
+        <%= image_tag "icons/wand.svg", alt: "Generate", width: 25, height: 25 %>
       </button>
 
       <%= render "shared/visibility_button" %>
@@ -94,7 +94,7 @@
                           "x-bind:type" => "show ? 'text' : 'password'"%>
 
       <button type="button" class="action" title="Generate API key" x-on:click="generateKey(); show = true">
-        <%= image_tag "icons/refresh.svg", alt: "Generate", width: 25, height: 25 %>
+        <%= image_tag "icons/wand.svg", alt: "Generate", width: 25, height: 25 %>
       </button>
 
       <%= render "shared/visibility_button" %>


### PR DESCRIPTION
## Overview

Since many users of Terminus are bringing their own devices (BYOD), TRMNL.com auto-generates and assigns an arbitrary, random MAC address and API keys and allows the user to edit/regenerate them if needed. However, on Terminus, there is always plaintext for the MAC address  and API key, requiring the user to generate these elseware. This PR adds a helper button to auto-generate these.

## Screenshots/Screencasts

<img width="2304" height="1218" alt="image" src="https://github.com/user-attachments/assets/6f9d628b-01f1-4813-8479-4e31312b7624" />

## Details

Let me know if there is a different way you'd like me to implement this. I did use the assistance of LLMs in this pull request, but manually set up the dev server and validated these changes work, both for the "New Device" and "Edit Device" screen.

Hoping to submit more quality-of-live UX PRs to this repo. Hope these are welcome