### PR TITLE
Added automatic MAC address generation for virtual devices

### DIFF
--- a/app/aspects/devices/defaulter.rb
+++ b/app/aspects/devices/defaulter.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "initable"
 require "securerandom"
 
 module Terminus
@@ -8,11 +7,15 @@ module Terminus
     module Devices
       # Builds default attributes for new devices.
       class Defaulter
-        include Initable[randomizer: SecureRandom]
+        def initialize randomizer: SecureRandom, mac_address_builder: Devices::MACAddressBuilder
+          @randomizer = randomizer
+          @mac_address_builder = mac_address_builder
+        end
 
         def call
           {
             api_key: randomizer.alphanumeric(20),
+            mac_address: mac_address_builder.call,
             firmware_update: true,
             friendly_id: randomizer.hex(3).upcase,
             image_timeout: 0,
@@ -20,6 +23,10 @@ module Terminus
             refresh_rate: 900
           }
         end
+
+        private
+
+        attr_reader :randomizer, :mac_address_builder
       end
     end
   end

--- a/app/aspects/devices/mac_address_builder.rb
+++ b/app/aspects/devices/mac_address_builder.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Terminus
+  module Aspects
+    module Devices
+      # Builds a random, locally administered, unicast MAC address.
+      MACAddressBuilder = lambda do |randomizer: SecureRandom|
+        zero_mask = 0xFC   # 11111100
+        local_mask = 0x02  # 00000010
+        bytes = randomizer.bytes(6).unpack "C*"
+        bytes[0] = (bytes[0] & zero_mask) | local_mask
+
+        bytes.map { format "%02X", it }
+             .join ":"
+      end
+    end
+  end
+end

--- a/app/aspects/devices/provisioner.rb
+++ b/app/aspects/devices/provisioner.rb
@@ -19,7 +19,7 @@ module Terminus
         include Dry::Monads[:result]
         include Pipeable
 
-        def call(mac_address:, **)
+        def call(mac_address: MACAddressBuilder.call, **)
           device = repository.find_by(mac_address:)
 
           return Success device if device

--- a/app/schemas/devices/upsert.rb
+++ b/app/schemas/devices/upsert.rb
@@ -10,7 +10,7 @@ module Terminus
         required(:playlist_id).maybe :integer
         optional(:label).filled :string
         optional(:friendly_id).filled :string
-        required(:mac_address).filled Types::MACAddress
+        optional(:mac_address).filled Types::MACAddress
         optional(:api_key).filled :string
         optional(:refresh_rate).filled :integer, gt?: 0
         optional(:image_timeout).filled :integer, gteq?: 0

--- a/app/templates/devices/shared/popovers/_mac_address.html.erb
+++ b/app/templates/devices/shared/popovers/_mac_address.html.erb
@@ -1,3 +1,5 @@
 <%= scope(:popover_default_content, name: :mac_address, label: "MAC Address").render do %>
-  <p>Uniquely identifies your device when communicating over the network. Must consist of six segments, be capitalized, and only use hexadecimal characters. Example: <code>A1:B2:C3:D4:E5:F6</code>.</p>
+  <p>Uniquely identifies your device when communicating over the network. Must consist of six segments, be capitalized, and only use hexadecimal characters. Example: <code>02:A1:B2:C3:D4:E5</code>.</p>
+
+  <p>By default, a locally administered, unicast, address is auto-generated for you which is handy when using virtual devices. For physical devices, please use the actual MAC address of your device in order to connect to it properly.</p>
 <% end %>

--- a/config/app.rb
+++ b/config/app.rb
@@ -22,7 +22,7 @@ module Terminus
       end
     end
 
-    config.inflections { it.acronym "DEFAULTS", "HTML", "IP", "URI" }
+    config.inflections { it.acronym "DEFAULTS", "HTML", "IP", "MAC", "URI" }
 
     config.actions.content_security_policy.then do |csp|
       csp[:connect_src] += " https://trmnl.com"

--- a/doc/api.adoc
+++ b/doc/api.adoc
@@ -254,7 +254,7 @@ curl "https://localhost:2443/api/devices/1" \
       "playlist_id": 1,
       "friendly_id": "DEMO11",
       "label": "Demo",
-      "mac_address": "A1:B2:C3:D4:E5:F6",
+      "mac_address": "02:A1:B2:C3:D4:E5",
       "api_key": "OScdcN0kFbKjFcid9Kz6Cx",
       "firmware_version": "1.7.8",
       "wifi": -71,
@@ -283,7 +283,7 @@ curl "https://localhost:2443/api/devices/1" \
     "playlist_id": 1,
     "friendly_id": "DEMO11",
     "label": "Demo",
-    "mac_address": "A1:B2:C3:D4:E5:F6",
+    "mac_address": "02:A1:B2:C3:D4:E5",
     "api_key": "OScdcN0kFbKjFcid9Kz6Cx",
     "firmware_version": "1.7.8",
     "wifi": -71,
@@ -319,9 +319,7 @@ curl -X "POST" "https://localhost:2443/api/devices" \
      -d $'{
   "device": {
     "model_id": 1,
-    "playlist_id": null,
-    "label": "Demo",
-    "mac_address": "A1:B2:C3:D4:E5:F6"
+    "playlist_id": 1
   }
 }'
 ----
@@ -338,7 +336,7 @@ curl -X "POST" "https://localhost:2443/api/devices" \
     "playlist_id": 1,
     "label": "Demo",
     "friendly_id": "DEMO11",
-    "mac_address": "A1:B2:C3:D4:E5:F6",
+    "mac_address": "02:A1:B2:C3:D4:E5",
     "api_key": "OScdcN0kFbKjFcid9Kz6Cx",
     "refresh_rate": 500,
     "image_timeout": 0,
@@ -356,6 +354,10 @@ curl -X "POST" "https://localhost:2443/api/devices" \
   }
 }'
 ----
+
+💡 If you don't need a playlist, you can supply `null` for the `playlist_id`.
+
+💡 When the `mac_address` is not supplied, a locally administered (unicast) MAC address will be generated for you so you can experiment with a virtual device. If you don't want this behavior, ensure you supply the actual MAC address of your physical device.
 ====
 
 .POST Response
@@ -370,7 +372,7 @@ curl -X "POST" "https://localhost:2443/api/devices" \
     "playlist_id": 1,
     "friendly_id": "DEMO11",
     "label": "Demo",
-    "mac_address": "A1:B2:C3:D4:E5:F6",
+    "mac_address": "02:A1:B2:C3:D4:E5",
     "api_key": "OScdcN0kFbKjFcid9Kz6Cx",
     "firmware_version": null,
     "wifi": 0,
@@ -424,7 +426,7 @@ You can change a single attribute or multiple attributes at once. All attributes
     "playlist_id": 1,
     "friendly_id": "DEMO11",
     "label": "Demo",
-    "mac_address": "A1:B2:C3:D4:E5:F6",
+    "mac_address": "02:A1:B2:C3:D4:E5",
     "api_key": "OScdcN0kFbKjFcid9Kz6Cx",
     "firmware_version": "1.7.8",
     "wifi": -71,
@@ -470,7 +472,7 @@ curl -X "DELETE" "https://localhost:2443/api/devices/1" \
     "playlist_id": 1,
     "friendly_id": "DEMO11",
     "label": "Demo",
-    "mac_address": "A1:B2:C3:D4:E5:F6",
+    "mac_address": "02:A1:B2:C3:D4:E5",
     "api_key": "OScdcN0kFbKjFcid9Kz6Cx",
     "firmware_version": "1.7.8",
     "wifi": -71,

--- a/spec/app/aspects/devices/defaulter_spec.rb
+++ b/spec/app/aspects/devices/defaulter_spec.rb
@@ -3,16 +3,29 @@
 require "hanami_helper"
 
 RSpec.describe Terminus::Aspects::Devices::Defaulter do
-  subject(:builder) { described_class.new randomizer: }
-
-  let :randomizer do
-    class_double SecureRandom, hex: "abc123", alphanumeric: "Ov2tWq4XoYCH2xPfiZqc"
-  end
+  subject(:builder) { described_class.new }
 
   describe "#call" do
-    it "answers defaults" do
+    it "answers random defaults" do
+      expect(builder.call).to match(
+        api_key: match_device_api_key,
+        mac_address: match_mac_address,
+        firmware_update: true,
+        friendly_id: match_device_friendly_id,
+        image_timeout: 0,
+        label: "TRMNL",
+        refresh_rate: 900
+      )
+    end
+
+    it "answers exact defaults" do
+      randomizer = class_double SecureRandom, hex: "abc123", alphanumeric: "Ov2tWq4XoYCH2xPfiZqc"
+      mac_address_builder = instance_double Proc, call: "02:A1:B2:C3:D4:E5"
+      builder = described_class.new(randomizer:, mac_address_builder:)
+
       expect(builder.call).to eq(
         api_key: "Ov2tWq4XoYCH2xPfiZqc",
+        mac_address: "02:A1:B2:C3:D4:E5",
         firmware_update: true,
         friendly_id: "ABC123",
         image_timeout: 0,

--- a/spec/app/aspects/devices/mac_address_builder_spec.rb
+++ b/spec/app/aspects/devices/mac_address_builder_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Aspects::Devices::MACAddressBuilder do
+  subject(:builder) { described_class }
+
+  describe "#call" do
+    let(:randomizer) { class_double SecureRandom }
+
+    it "answers random address" do
+      result = Terminus::Types::MACAddress.valid? builder.call
+      expect(result).to be(true)
+    end
+
+    it "ensures first octet ends in 2 for valid locally administered (unicast) address" do
+      allow(randomizer).to receive(:bytes).with(6) do
+        [0b00000000, 0x3d, 0x7c, 0x70, 0xa9, 0x0a].pack "C*"
+      end
+
+      expect(builder.call(randomizer:)).to eq("02:3D:7C:70:A9:0A")
+    end
+
+    it "ensures first octet ends in 6 for valid locally administered (unicast) address" do
+      allow(randomizer).to receive(:bytes).with(6) do
+        [0b00000100, 0x3d, 0x7c, 0x70, 0xa9, 0x0a].pack "C*"
+      end
+
+      expect(builder.call(randomizer:)).to eq("06:3D:7C:70:A9:0A")
+    end
+
+    it "ensures first octet ends in A for valid locally administered (unicast) address" do
+      allow(randomizer).to receive(:bytes).with(6) do
+        [0b00001000, 0x3d, 0x7c, 0x70, 0xa9, 0x0a].pack "C*"
+      end
+
+      expect(builder.call(randomizer:)).to eq("0A:3D:7C:70:A9:0A")
+    end
+
+    it "ensures first octet ends in E for valid locally administered (unicast) address" do
+      allow(randomizer).to receive(:bytes).with(6) do
+        [0b00001100, 0x3d, 0x7c, 0x70, 0xa9, 0x0a].pack "C*"
+      end
+
+      expect(builder.call(randomizer:)).to eq("0E:3D:7C:70:A9:0A")
+    end
+  end
+end

--- a/spec/app/aspects/devices/provisioner_spec.rb
+++ b/spec/app/aspects/devices/provisioner_spec.rb
@@ -7,26 +7,35 @@ RSpec.describe Terminus::Aspects::Devices::Provisioner, :db do
 
   describe "#call" do
     it "answers existing device" do
-      device = Factory[:device, mac_address: "A1:B2:C3:D4:E5:F6"]
+      device = Factory[:device, mac_address: "02:A1:B2:C3:D4:E5"]
       result = provisioner.call mac_address: device.mac_address
 
-      expect(result.success).to have_attributes(playlist_id: nil, mac_address: "A1:B2:C3:D4:E5:F6")
+      expect(result.success).to have_attributes(playlist_id: nil, mac_address: "02:A1:B2:C3:D4:E5")
     end
 
     context "with new device" do
       let(:model) { Factory[:model] }
 
-      it "answers device" do
-        result = provisioner.call mac_address: "A1:B2:C3:D4:E5:F6", model_id: model.id
+      it "answers device with given MAC address" do
+        result = provisioner.call mac_address: "02:A1:B2:C3:D4:E5", model_id: model.id
 
         expect(result.success).to have_attributes(
           model_id: model.id,
-          mac_address: "A1:B2:C3:D4:E5:F6"
+          mac_address: "02:A1:B2:C3:D4:E5"
+        )
+      end
+
+      it "answers device with virtual MAC address" do
+        result = provisioner.call model_id: model.id
+
+        expect(result.success).to have_attributes(
+          model_id: model.id,
+          mac_address: match_mac_address
         )
       end
 
       it "associates device with playlist" do
-        device = provisioner.call(mac_address: "A1:B2:C3:D4:E5:F6", model_id: model.id).success
+        device = provisioner.call(mac_address: "02:A1:B2:C3:D4:E5", model_id: model.id).success
         playlist = Terminus::Repositories::Playlist.new.find device.playlist_id
 
         expect(playlist).to have_attributes(
@@ -36,7 +45,7 @@ RSpec.describe Terminus::Aspects::Devices::Provisioner, :db do
       end
 
       it "associates playlist item with welcome screen" do
-        device = provisioner.call(mac_address: "A1:B2:C3:D4:E5:F6", model_id: model.id).success
+        device = provisioner.call(mac_address: "02:A1:B2:C3:D4:E5", model_id: model.id).success
         item = Terminus::Repositories::PlaylistItem.new.find_by playlist_id: device.playlist_id
         screen = item.screen
 
@@ -48,7 +57,7 @@ RSpec.describe Terminus::Aspects::Devices::Provisioner, :db do
       end
 
       it "associates playlist current item with welcome screen" do
-        device = provisioner.call(mac_address: "A1:B2:C3:D4:E5:F6", model_id: model.id).success
+        device = provisioner.call(mac_address: "02:A1:B2:C3:D4:E5", model_id: model.id).success
         playlist = Terminus::Repositories::Playlist.new.find device.playlist_id
         screen = Terminus::Repositories::Screen.new.find playlist.current_item.screen_id
 
@@ -59,7 +68,7 @@ RSpec.describe Terminus::Aspects::Devices::Provisioner, :db do
       end
 
       it "answers failure with nil model ID" do
-        result = provisioner.call mac_address: "A1:B2:C3:D4:E5:F6", model_id: nil
+        result = provisioner.call mac_address: "02:A1:B2:C3:D4:E5", model_id: nil
 
         expect(result).to be_failure(
           %(Null value in column "model_id" of relation "device" violates not-null constraint.)
@@ -67,7 +76,7 @@ RSpec.describe Terminus::Aspects::Devices::Provisioner, :db do
       end
 
       it "answers failure with invalid model ID" do
-        result = provisioner.call mac_address: "A1:B2:C3:D4:E5:F6", model_id: 13
+        result = provisioner.call mac_address: "02:A1:B2:C3:D4:E5", model_id: 13
         expect(result).to be_failure(%(Key (model_id)=(13) is not present in table "model".))
       end
     end

--- a/spec/app/aspects/screens/fetcher_spec.rb
+++ b/spec/app/aspects/screens/fetcher_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe Terminus::Aspects::Screens::Fetcher, :db do
   subject(:fetcher) { described_class.new }
 
   describe "#call" do
-    let :device do
-      provisioner.call(model_id: Factory[:model].id, mac_address: "A1:B2:C3:D4:E5:F6").value!
-    end
-
+    let(:device) { provisioner.call(model_id: Factory[:model].id).value! }
     let(:provisioner) { Terminus::Aspects::Devices::Provisioner.new }
     let(:playlist_repository) { Terminus::Repositories::Playlist.new }
     let(:item_repository) { Terminus::Repositories::PlaylistItem.new }

--- a/spec/app/aspects/screens/rotator_spec.rb
+++ b/spec/app/aspects/screens/rotator_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe Terminus::Aspects::Screens::Rotator, :db do
   subject(:rotator) { described_class.new }
 
   describe "#call" do
-    let :device do
-      provisioner.call(model_id: Factory[:model].id, mac_address: "A1:B2:C3:D4:E5:F6").value!
-    end
-
+    let(:device) { provisioner.call(model_id: Factory[:model].id).value! }
     let(:provisioner) { Terminus::Aspects::Devices::Provisioner.new }
     let(:playlist_repository) { Terminus::Repositories::Playlist.new }
     let(:item_repository) { Terminus::Repositories::PlaylistItem.new }

--- a/spec/app/views/parts/device_spec.rb
+++ b/spec/app/views/parts/device_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe Terminus::Views::Parts::Device, :db do
 
   describe "#current_screen" do
     let :device do
-      attributes = {model_id: Factory[:model].id, mac_address: "A1:B2:C3:D4:E5:F6"}
-      Terminus::Aspects::Devices::Provisioner.new.call(**attributes).value!
+      Terminus::Aspects::Devices::Provisioner.new.call(model_id: Factory[:model].id).value!
     end
 
     it "answers screen when device is provisioned" do

--- a/spec/support/matchers/match_mac_address.rb
+++ b/spec/support/matchers/match_mac_address.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :match_mac_address do
+  match do |actual|
+    actual.match?(/\A[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}\Z/)
+  end
+end


### PR DESCRIPTION
## Overview

This ensures MAC addresses are generated for virtual devices by default which saves a step when setting up virtual devices.

## Details

- This builds upon what Ben started in [Code Review 301](https://github.com/usetrmnl/terminus/pull/301).