### PR TITLE
fix: docs - Extension Walkthrough (Ghibli) Source Schema Update

### DIFF
--- a/doc/extensions.adoc
+++ b/doc/extensions.adoc
@@ -59,7 +59,7 @@ To help you get started, let's walk through a scenario building an extension:
 ====
 [source,html]
 ----
-{% for film in source limit:5 %}
+{% for film in source_1 limit:5 %}
   <div class="item">
     <div class="meta">
       <span class="index">{{ forloop.index }}</span>


### PR DESCRIPTION
## Overview
The current version of the Extension Hello World example using Ghibli movies is nonfunctional due to what I assume is an API change. This is easily corrected via a minor tweak to the example code.

## Screenshots/Screencasts
To replicate simply run through the walkthrough as currently described in the docs and/or examine the return from `curl https://ghibliapi.vercel.app/films`

## Details
The existing docs use `source` as the meta wrapper/root/dohickey value for the return from the ghibli api call. This causes the screen to fail to render entirely due to either a typo or an API change post initial publishing of the guide. Updating the template to match the source's root of `source_1` gets things working as expected.