### PR TITLE
Fixed device battery voltage percentage gaps

### DIFF
--- a/app/views/parts/device.rb
+++ b/app/views/parts/device.rb
@@ -47,14 +47,14 @@ module Terminus
           case battery_voltage
             when 0 then 0
             when ..0.45 then 10
-            when 0.46..0.9 then 20
-            when 1.0..1.35 then 30
-            when 1.36..1.8 then 40
-            when 1.81..2.25 then 50
-            when 2.26..2.7 then 60
-            when 2.71..3.15 then 70
-            when 3.16..3.6 then 80
-            when 3.61..4.05 then 90
+            when ..0.9 then 20
+            when ..1.35 then 30
+            when ..1.8 then 40
+            when ..2.25 then 50
+            when ..2.7 then 60
+            when ..3.15 then 70
+            when ..3.6 then 80
+            when ..4.05 then 90
             else 100
           end
         end

--- a/spec/app/views/parts/device_spec.rb
+++ b/spec/app/views/parts/device_spec.rb
@@ -62,9 +62,19 @@ RSpec.describe Terminus::Views::Parts::Device, :db do
       expect(part.battery_percentage).to eq(10)
     end
 
+    it "answers twenty percent when voltage is just above the ten percent band" do
+      allow(device).to receive(:battery_voltage).and_return(0.455)
+      expect(part.battery_percentage).to eq(20)
+    end
+
     it "answers twenty percent when voltage is in range" do
       allow(device).to receive(:battery_voltage).and_return(0.75)
       expect(part.battery_percentage).to eq(20)
+    end
+
+    it "answers thirty percent when voltage is just above the twenty percent band" do
+      allow(device).to receive(:battery_voltage).and_return(0.95)
+      expect(part.battery_percentage).to eq(30)
     end
 
     it "answers thirty percent when voltage is in range" do
@@ -95,6 +105,11 @@ RSpec.describe Terminus::Views::Parts::Device, :db do
     it "answers eighty percent when voltage is in range" do
       allow(device).to receive(:battery_voltage).and_return(3.3)
       expect(part.battery_percentage).to eq(80)
+    end
+
+    it "answers ninety percent when voltage is just above the eighty percent band" do
+      allow(device).to receive(:battery_voltage).and_return(3.605)
+      expect(part.battery_percentage).to eq(90)
     end
 
     it "answers ninety percent when voltage is in range" do


### PR DESCRIPTION
## Overview

`Views::Parts::Device#battery_voltage_to_percent` maps a floating-point battery voltage into 10% bands, but the bands left uncovered gaps between each range, so any voltage landing in a gap fell through to the `else 100` default. A normal mid-charge reading such as `3.605V` therefore displayed as **100% battery** on the device dashboard.

## Details

- Before, the bands were e.g. `0.46..0.9` then `1.0..1.35`, and `3.16..3.6` then `3.61..4.05` — leaving holes (`0.9 < v < 1.0`, `3.6 < v < 3.61`, and similar). Any voltage in a hole matched no `when` clause and returned 100%.
- This value is rendered directly on the device dashboard in `app/templates/devices/_measurements.html.erb`, as both the meter value and the `% Battery` label.
- Fix: contiguous cascading beginless ranges so every voltage maps to its nearest band.
- All 13 values asserted by the existing spec are preserved unchanged; three regression examples were added for voltages that previously fell in the gaps (`0.455 → 20%`, `0.95 → 30%`, `3.605 → 90%`).

_Note: an earlier revision of this PR also bundled an unrelated defensive guard on the `DefaultToArray` coercer. I've dropped it to keep this PR single-purpose; it can be revisited separately with a concrete reproduction._