### PR TITLE
Fixed playlist item position scoping

### DIFF
--- a/app/repositories/playlist_item.rb
+++ b/app/repositories/playlist_item.rb
@@ -15,10 +15,12 @@ module Terminus
                          .to_a
       end
 
-      def create_with_position(offset: 1, **)
+      def create_with_position(playlist_id:, offset: 1, **)
         playlist_item.transaction do
+          position = playlist_item.where(playlist_id:).max(:position).to_i + offset
+
           playlist_item.command(:create)
-                       .call(position: playlist_item.count + offset, **)
+                       .call(playlist_id:, position:, **)
                        .then { find it.id }
         end
       end

--- a/spec/app/repositories/playlist_item_spec.rb
+++ b/spec/app/repositories/playlist_item_spec.rb
@@ -34,6 +34,23 @@ RSpec.describe Terminus::Repositories::PlaylistItem, :db do
         screen: kind_of(Terminus::Structs::Screen)
       )
     end
+
+    it "answers position scoped to playlist" do
+      other = Factory[:playlist]
+      repository.create_with_position playlist_id: other.id, screen_id: screen.id
+      item = repository.create_with_position playlist_id: playlist.id, screen_id: screen.id
+
+      expect(item.position).to eq(1)
+    end
+
+    it "answers next position after an item is deleted" do
+      first = repository.create_with_position playlist_id: playlist.id, screen_id: screen.id
+      repository.create_with_position playlist_id: playlist.id, screen_id: screen.id
+      repository.delete first.id
+      item = repository.create_with_position playlist_id: playlist.id, screen_id: screen.id
+
+      expect(item.position).to eq(3)
+    end
   end
 
   describe "#delete_all" do


### PR DESCRIPTION
## Overview

`Repositories::PlaylistItem#create_with_position` derived the next position from `playlist_item.count` — the **global** row count across all playlists — rather than the count for the target playlist. Combined with the `(playlist_id, position)` unique index and deletions that don't renumber, this could assign a colliding position and raise `ROM::SQL::UniqueConstraintError`.

## Details

- **Reproduce:** add two items to a playlist (positions 1, 2) → delete the first → add another. The new position is computed as `count(1) + 1 = 2`, which already exists in that playlist → `ROM::SQL::UniqueConstraintError`, and the request 500s (neither `Items::Create` nor `create_with_position` rescues it).
- A new playlist's first item could also start above position `1` whenever other playlists already held items.
- Affects all three callers: `Actions::Playlists::Items::Create`, `Actions::Api::Screens::Create`, and `Aspects::Devices::Provisioner`.
- **Fix:** scope the next position to the target playlist's current maximum — `where(playlist_id:).max(:position).to_i + offset` — using the same relation aggregate family as the `count` it replaces (`.max` returns `nil` for an empty playlist, so the first item is position `1`).
- Added two specs: position is scoped per playlist, and a regression for the post-deletion collision. The existing `"answers item with position"` example still passes (`nil → 1`, then `1 → 2`).