### PR TITLE
Fixed playlist mirror detaching devices on other playlists

### DIFF
--- a/app/repositories/device.rb
+++ b/app/repositories/device.rb
@@ -20,7 +20,8 @@ module Terminus
       def find_by(**) = with_associations.where(**).one
 
       def mirror_playlist ids, playlist_id
-        device.update playlist_id: Sequel.case({{id: ids} => playlist_id}, nil)
+        device.where(Sequel.|({id: ids}, {playlist_id:}))
+              .update(playlist_id: Sequel.case({{id: ids} => playlist_id}, nil))
       end
 
       def search key, value

--- a/spec/app/repositories/device_spec.rb
+++ b/spec/app/repositories/device_spec.rb
@@ -75,6 +75,23 @@ RSpec.describe Terminus::Repositories::Device, :db do
       result = repository.mirror_playlist [], playlist.id
       expect(result).to eq(0)
     end
+
+    it "doesn't detach devices belonging to other playlists" do
+      other_playlist = Factory[:playlist]
+      other_device = Factory[:device, playlist_id: other_playlist.id]
+
+      repository.mirror_playlist [device.id], playlist.id
+
+      expect(repository.find(other_device.id).playlist_id).to eq(other_playlist.id)
+    end
+
+    it "detaches deselected devices that belong to this playlist" do
+      device = Factory[:device, playlist_id: playlist.id]
+
+      repository.mirror_playlist [], playlist.id
+
+      expect(repository.find(device.id).playlist_id).to be(nil)
+    end
   end
 
   describe "#search" do


### PR DESCRIPTION
## Problem

`Repositories::Device#mirror_playlist` runs an **unscoped** `UPDATE` across the entire `device` table:

```ruby
def mirror_playlist ids, playlist_id
  device.update playlist_id: Sequel.case({{id: ids} => playlist_id}, nil)
end
```

The `CASE … ELSE NULL` is applied to *every* device, so the `ELSE` branch clears `playlist_id` on all devices that aren't in `ids` — **including devices assigned to other playlists**. Two real consequences from the mirror form (`Playlists::Mirror::Update`):

- Mirroring playlist A detaches every device currently mirroring playlist B (their `playlist_id` is set to `NULL`).
- Submitting with no devices checked omits the `mirror` param, so `device_ids` is `nil` and **every device in the system** is detached from its playlist.

The existing `mirror_playlist []` spec only passed because no device existed in that example, so the behavior went unnoticed.

## Fix

Scope the `UPDATE` to just the selected devices *or* devices already on this playlist:

```ruby
device.where(Sequel.|({id: ids}, {playlist_id:}))
      .update(playlist_id: Sequel.case({{id: ids} => playlist_id}, nil))
```

This preserves other playlists' assignments while still:
- attaching selected devices to this playlist, and
- detaching deselected devices that belonged to this playlist (including the "uncheck everything" case, which now only clears *this* playlist).

## Tests

Added two repository specs:
- `doesn't detach devices belonging to other playlists` — fails on `main`, passes with the fix.
- `detaches deselected devices that belong to this playlist` — guards the legitimate detach behavior.

Milestone: patch