### PR TITLE
Allow JWT refresh with an expired access token

### DIFF
--- a/doc/api.adoc
+++ b/doc/api.adoc
@@ -200,7 +200,7 @@ Your login (email) and password must be identical to what you supplied during th
 
 ==== Refresh Tokens
 
-To refresh your `access_token` before it has expired (default: 30 minutes), you'll need to make an API request to the following endpoint:
+To refresh your `access_token` (valid for 30 minutes by default), make an API request to the following endpoint. This works before or after the access token has expired, as long as the refresh token is within its own deadline:
 
 [source,bash]
 ----

--- a/slices/authentication/middleware.rb
+++ b/slices/authentication/middleware.rb
@@ -104,6 +104,10 @@ module Authentication
       jwt_refresh_route "api/jwt"
 
       # Feature: jwt_refresh
+      # Allows refresh after access token expiry so headless API clients can
+      # recover without re-sending credentials. Refresh tokens remain HMAC
+      # verified, single use, and deadline limited.
+      allow_refresh_with_expired_jwt_access_token? true
       jwt_access_token_period Hanami.app[:settings].api_access_token_period
       jwt_refresh_token_account_id_column :user_id
       jwt_refresh_token_table :user_jwt_refresh_key


### PR DESCRIPTION
Allows POST /api/jwt to refresh with an expired access token.

- API clients that call less often than the access token period (30 minutes by default) can currently never refresh — the endpoint rejects the expired token and the only recovery is re-sending credentials. The Home Assistant add-on hits this on any schedule running less often than every 30 minutes
- Refresh tokens are unchanged: HMAC-bound to the session, single use, and limited by their own deadline
- Verified against a running instance with a short token period: expired access + valid refresh returns a fresh pair, expired access + invalid refresh token is still rejected
- Updated the API doc to match