### PR TITLE
docker compose: make the Framework fonts available locally

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -61,6 +61,8 @@ services:
     volumes:
       - certificates:/etc/ssl/certs
       - web-uploads:/app/public/uploads
+      - fonts:/usr/share/fonts/terminus
+      - fonts:/app/public/fonts
     depends_on:
       web:
         condition: service_healthy
@@ -129,3 +131,4 @@ volumes:
   keyvalue-data:
   web-uploads:
   certificates:
+  fonts:


### PR DESCRIPTION
I'm using Terminus via docker compose. I noticed that the preview rendering used the Inter font as expected, but the final rendered screen used the container's system font instead.

I found #287, and that's exactly what I'm seeing. Except that that issues was supposedly fixed via 0d79c8bb2688fda114ef6f552b4daec2d0688d71, 7f6d8a8990df07ec845e2df36f8fd2df4c38b44c, and b0b5fc23c6dc058139f8deadc8db61728910dfaf.

I don't know why exactly it still doesn't work for me (I'm not a rubyist, and in particular I don't know how ferrum deals with web fonts).

But what made it work for me was the change in this PR: Also mount the fonts into `/usr/share/fonts`, so they're available as local fonts in the container. After this change, the screen rendered as expected.

I also tried disabling and re-enabling this change a couple of times, and that consistently toggled things between working or not working.

So this clearly is the fix for me, albeit slightly unsatisfying because I'm not sure *why* things don't work via the webfont route.

So I'm considering this a workaround. Not sure if that's something you'd want to merge; otherwise, consider it documentation for a potential workaround 😄

