### PR TITLE
allow non-https images

### DIFF
--- a/config/app.rb
+++ b/config/app.rb
@@ -28,6 +28,7 @@ module Terminus
       csp[:connect_src] += " https://trmnl.com"
       csp[:font_src] += " https://trmnl.com"
       csp[:manifest_src] = "'self'"
+      csp[:img_src] = "'self' data: http:"
       csp[:script_src] += " 'unsafe-eval' 'unsafe-inline' https://trmnl.com"
     end
 


### PR DESCRIPTION
The default content security policy for images seems to be `'self' data: https:`.

I think it's reasonable to allow images served over `http://`, since the point of BYOS is that you're probably running everything in your internal network, where you're not necessarily configuring things for TLS. At least that's the case for me.

(Could also be a config option instead -- the change here is just the simple fix I made for myself.)
