### PR TITLE
Fixed POST exchange body being dropped on fetch

### DIFF
--- a/app/aspects/extensions/fetchers/sole.rb
+++ b/app/aspects/extensions/fetchers/sole.rb
@@ -23,15 +23,24 @@ module Terminus
           private
 
           def process input
-            http.headers(input.headers)
-                .follow
-                .public_send(input.verb, input.uri)
-                .then { it.status.success? ? Success(it) : build_detailed_failure(input, it) }
+            request(input)
+              .then { it.status.success? ? Success(it) : build_detailed_failure(input, it) }
           rescue HTTP::RequestError then build_failure input, "Unable to make request"
           rescue HTTP::ConnectionError then build_failure input, "Unable to connect"
           rescue HTTP::TimeoutError then build_failure input, "Connection timed out"
           rescue OpenSSL::SSL::SSLError then build_failure input, "Unable to secure connection"
           end
+
+          # Forwards the body as JSON for verbs that carry one (e.g. POST). Without
+          # this, the body configured on an exchange is silently dropped.
+          # :reek:FeatureEnvy
+          def request input
+            http.headers(input.headers)
+                .follow
+                .public_send input.verb, input.uri, **options_for(input.body)
+          end
+
+          def options_for(body) = Hash(body).empty? ? Core::EMPTY_HASH : {json: body}
 
           def maybe_alter_mime_type headers, response
             type = headers && headers[special_header]

--- a/spec/app/aspects/extensions/fetchers/sole_spec.rb
+++ b/spec/app/aspects/extensions/fetchers/sole_spec.rb
@@ -340,6 +340,59 @@ RSpec.describe Terminus::Aspects::Extensions::Fetchers::Sole do
       end
     end
 
+    context "with POST and body" do
+      let :input do
+        Terminus::Aspects::Extensions::Fetchers::Input[
+          headers: {"Content-Type" => "application/json"},
+          verb: "post",
+          uri: "https://example.com/api",
+          body: {"query" => "test"}
+        ]
+      end
+
+      before do
+        response = HTTP::Response.new headers: {content_type: "application/json"},
+                                      body: {"ok" => true}.to_json,
+                                      status: 200,
+                                      version: 1.0
+
+        allow(http).to receive(:post).and_return response
+      end
+
+      it "forwards the body as JSON" do
+        fetcher.call input
+        expect(http).to have_received(:post).with(input.uri, json: {"query" => "test"})
+      end
+
+      it "answers success" do
+        expect(fetcher.call(input)).to be_success(data: {"ok" => true}, error: {})
+      end
+    end
+
+    context "with POST and no body" do
+      let :input do
+        Terminus::Aspects::Extensions::Fetchers::Input[
+          headers: {"Content-Type" => "application/json"},
+          verb: "post",
+          uri: "https://example.com/api"
+        ]
+      end
+
+      before do
+        response = HTTP::Response.new headers: {content_type: "application/json"},
+                                      body: {"ok" => true}.to_json,
+                                      status: 200,
+                                      version: 1.0
+
+        allow(http).to receive(:post).and_return response
+      end
+
+      it "sends no body" do
+        fetcher.call input
+        expect(http).to have_received(:post).with(input.uri)
+      end
+    end
+
     context "with unknown MIME type" do
       before do
         response = HTTP::Response.new headers: {content_type: "text/html"},


### PR DESCRIPTION
## Overview

Extension exchanges persist a request `body` (the schema has a `body` jsonb column, and `Curler` renders it into the preview `curl` command), but `Aspects::Extensions::Fetchers::Sole#process` never forwarded it to the actual HTTP request:

```ruby
http.headers(input.headers).follow.public_send(input.verb, input.uri)
```

So every POST exchange fired with an **empty body**. APIs that require a JSON body reject the request — e.g. Home Assistant's `/api/template` responds `400 {"message":"Template data should be a JSON object."}`. The preview curl (which does include the body) and the real request diverged, making this hard to spot.

## Details

- `Sole#process` now forwards `input.body` as `json:` for requests that carry one, via a small `request_options` helper.
- GET and bodyless requests are unchanged (empty body → no extra args), so existing behavior and specs are unaffected.
- Added specs: POST with a body forwards it as `json:`; POST without a body sends none.
