### PR TITLE
Allow data attributes on all elements

### DIFF
--- a/app/aspects/sanitizer.rb
+++ b/app/aspects/sanitizer.rb
@@ -52,7 +52,9 @@ module Terminus
       end
 
       def merge_attributes configuration
-        defaults[:attributes].merge configuration.fetch("attributes")
+        defaults[:attributes].merge configuration.fetch("attributes") do |_element, default_attributes, custom_attributes|
+          default_attributes.to_a.including(*custom_attributes)
+        end
       end
     end
   end

--- a/config/sanitize.yml
+++ b/config/sanitize.yml
@@ -26,6 +26,9 @@ elements:
   - text
   - tspan
 attributes:
+  # Allow data-* attributes so the framework runtime hooks survive
+  :all:
+    - :data
   canvas:
     - id
     - width
@@ -43,8 +46,6 @@ attributes:
     - fill-opacity
     - shape-rendering
     - transform
-  div:
-    - :data
   ellipse:
     - cx
     - cv

--- a/spec/app/aspects/sanitizer_spec.rb
+++ b/spec/app/aspects/sanitizer_spec.rb
@@ -58,6 +58,34 @@ RSpec.describe Terminus::Aspects::Sanitizer do
       expect(sanitizer.call(source)).to eq(source)
     end
 
+    it "allows data attributes on non-div elements" do
+      source = <<~HTML.squeeze(" ").delete("\n").strip
+        <html><head></head>
+          <body>
+            <span data-value-fit="true"></span> <p data-clamp="3"></p> <table data-table-limit="true"></table>
+        </body></html>
+      HTML
+
+      expect(sanitizer.call(source)).to eq(source)
+    end
+
+    it "keeps default global attributes alongside data attributes" do
+      source = <<~HTML.squeeze(" ").delete("\n").strip
+        <html><head></head>
+          <body>
+            <span class="value" data-value-fit="true"></span>
+        </body></html>
+      HTML
+
+      expect(sanitizer.call(source)).to eq(source)
+    end
+
+    it "removes event handler attributes" do
+      source = %(<span data-x="1" onclick="alert(1)">test</span>)
+
+      expect(sanitizer.call(source)).not_to include("onclick")
+    end
+
     it "allows ellipse element with attributes" do
       source = <<~HTML.squeeze(" ").delete("\n").strip
         <html><head></head>


### PR DESCRIPTION
## Overview

The framework runtime attaches `data-*` hooks to a range of elements — `data-value-fit` on `<span>`, `data-table-limit` on `<table>`, `data-clamp` on `<p>`, `data-overflow` on `<div>`, etc.  (see https://trmnl.com/framework/docs/3.1).

While #324  fixed this for `div` every hook riding on other elements was stripped before the screenshot, and the feature it drives silently did nothing on a BYOS worker render.

To fix this I hoisted the `:data` to `:all:`. That also requires merge_attributes to union per key like its siblings merge_properties/merge_elements.

A more conservative alternative is to add `:data` only to the specific elements the framework targets (span, table, p, ...) rather than `:all`.