### PR TITLE
Added remote browser support via ferrum_url setting

### DIFF
--- a/app/aspects/screens/shoter.rb
+++ b/app/aspects/screens/shoter.rb
@@ -38,6 +38,14 @@ module Terminus
                              .slice(*options_map.keys)
                              .transform_keys!(options_map)
                              .merge!(browser_options:)
+
+          remote_url = settings.ferrum_url
+
+          return if remote_url.empty?
+
+          @options.delete :process_timeout
+          @options.delete :browser_options
+          @options[:url] = remote_url
         end
 
         def call(content, output_path, **viewport) = save content, viewport, output_path

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -13,6 +13,7 @@ module Terminus
     setting :ferrum_default_timeout, constructor: Types::Params::Integer, default: 30
     setting :ferrum_process_timeout, constructor: Types::Params::Integer, default: 15
     setting :ferrum_javascript_errors, constructor: Types::Params::Bool, default: true
+    setting :ferrum_url, constructor: Types::Params::String, default: ""
     setting :fonts_root,
             constructor: Terminus::Types::Pathname,
             default: Hanami.app.root.join("public/fonts")

--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -35,6 +35,7 @@ There are several environment variables you can use to customize behavior by upd
 * `FERRUM_DEFAULT_TIMEOUT`: Used for configuring {ferrum_link} headless browser default time allowed for the browser to respond to a request. Default: `30`.
 * `FERRUM_PROCESS_TIMEOUT`: Used for configuring {ferrum_link} headless browser time allowed for the browser to start. Default: `15`.
 * `FERRUM_JAVASCRIPT_ERRORS`: Used for configuring {ferrum_link} headless browser JavaScript errors. Default: `true`.
+* `FERRUM_URL`: Used for connecting {ferrum_link} to a remote browser (i.e. `http://browser:3000`) instead of spawning a local process. Useful when the host kernel can't run the bundled Chromium (i.e. older NAS hardware) and rendering is delegated to a sidecar container such as browserless. Default: `""` (spawn locally).
 * `FIRMWARE_SYNCHRONIZER`: Enables/disables firmware synchronization. See {doc_jobs_link} for details. Defaults to enabled.
 * `FONT_SYNCHRONIZER`: Enables/disables firmware synchronization. See {doc_jobs_link} for details. Defaults to enabled.
 * `FONTS_PATH`: The path to where {trmnl_framework_link} fonts are stored since the Framework stylesheets require a relative path to all fonts to load properly. This is necessary when rendering screens for {doc_extensions_link}. Default: `public/fonts`.

--- a/spec/app/aspects/screens/shoter_spec.rb
+++ b/spec/app/aspects/screens/shoter_spec.rb
@@ -48,6 +48,22 @@ RSpec.describe Terminus::Aspects::Screens::Shoter do
       expect(logger.reread).to match(/DEBUG.+Ferrum browser options\..+js_errors.+true/)
     end
 
+    context "with remote browser URL" do
+      subject(:shoter) { described_class.new browser: }
+
+      before { allow(settings).to receive(:ferrum_url).and_return "http://browser:3000" }
+
+      it "connects to remote browser" do
+        shoter.call content, path, width: 800, height: 480
+        expect(browser).to have_received(:new).with(hash_including(url: "http://browser:3000"))
+      end
+
+      it "excludes process options" do
+        shoter.call content, path, width: 800, height: 480
+        expect(browser).to have_received(:new).with(hash_excluding(:process_timeout, :browser_options))
+      end
+    end
+
     context "with browser error" do
       subject(:shoter) { described_class.new browser: }
 


### PR DESCRIPTION
## Overview

Adds an optional `ferrum_url` setting (`FERRUM_URL`) that connects the screen shoter to an existing browser over CDP instead of spawning Chromium locally. Local spawning remains the default; the setting is opt-in and empty by default.

This unblocks hosts whose kernels can't run modern Chromium. Example: Synology NAS units on platform-pinned 3.10 kernels — `chromium --dump-dom` works, but the devtools bootstrap crashes with SIGTRAP, so Ferrum waits out its process timeout and every screen request returns empty. Pointing `FERRUM_URL` at a sidecar container running an older-kernel-friendly Chrome (e.g. browserless) restores rendering with no other changes.

## Details

- `Shoter` passes `url:` to `Ferrum::Browser` when the setting is present, and drops `process_timeout`/`browser_options`, which only apply to locally spawned processes.
- Specs cover the remote path (connect options include `url`, exclude process options); `doc/configuration.adoc` documents the setting alongside the other `FERRUM_*` knobs.
- Running in production since 2026-07-08 on DSM 7.3 (kernel 3.10.108) with a `browserless/chrome` sidecar, rendering 1872x1404 screens.