### PR TITLE
Added API endpoint for building extensions on demand

### DIFF
--- a/app/actions/api/extensions/build/create.rb
+++ b/app/actions/api/extensions/build/create.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Terminus
+  module Actions
+    module API
+      module Extensions
+        module Build
+          # The create action.
+          class Create < Base
+            include Deps[repository: "repositories.extension"]
+            include Initable[job: Jobs::Batches::Extension]
+
+            params { required(:extension_id).filled :integer }
+
+            def handle request, response
+              extension = repository.find request.params[:extension_id]
+
+              if extension
+                enqueue extension, response
+              else
+                response.body = petail[status: :not_found].to_json
+              end
+            end
+
+            private
+
+            def enqueue extension, response
+              job.perform_async extension.id
+
+              response.status = 202
+              response.body = {data: {id: extension.id, enqueued: true}}.to_json
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,10 @@ module Terminus
       patch "/playlists/:id", to: "api.playlists.patch", as: :playlist
       delete "/playlists/:id", to: "api.playlists.delete", as: :playlist
 
+      post "/extensions/:extension_id/build",
+           to: "api.extensions.build.create",
+           as: :extension_build
+
       get "/screens", to: "api.screens.index", as: :screens
       post "/screens", to: "api.screens.create", as: :screens
       patch "/screens/:id", to: "api.screens.patch", as: :screen

--- a/doc/api.adoc
+++ b/doc/api.adoc
@@ -1313,6 +1313,35 @@ curl -X "DELETE" "https://localhost:2443/api/playlists/2" \
 You'll get an empty hash when there is nothing to delete.
 ====
 
+=== Extensions
+
+Allows you to trigger an extension build (screen regeneration) on demand — the API
+equivalent of the Build button — so automations can rebuild the moment source data
+changes instead of waiting for the extension's schedule.
+
+.POST Request
+[%collapsible]
+====
+[source,bash]
+----
+curl -X "POST" "https://localhost:2443/api/extensions/1/build"      -H 'Authorization: <redacted>'      -H 'Content-Type: application/json'
+----
+====
+
+.POST Response (202 Accepted)
+[%collapsible]
+====
+[source,json]
+----
+{
+  "data": {
+    "id": 1,
+    "enqueued": true
+  }
+}
+----
+====
+
 === Screens
 
 Used for managing device screens by supplying content for rendering, screenshotting, and grey scaling to render properly on your device. You can also use these optional keys when making requests:

--- a/spec/app/actions/api/extensions/build/create_spec.rb
+++ b/spec/app/actions/api/extensions/build/create_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "hanami_helper"
+
+RSpec.describe Terminus::Actions::API::Extensions::Build::Create, :db do
+  subject(:action) { described_class.new }
+
+  describe "#call" do
+    let(:extension) { Factory[:extension] }
+
+    let :response do
+      action.call Rack::MockRequest.env_for(
+        extension.id.to_s,
+        "router.params" => {extension_id: extension.id}
+      )
+    end
+
+    it "enqueues job" do
+      Sidekiq::Testing.fake! do
+        response
+
+        expect(Terminus::Jobs::Batches::Extension.jobs).to contain_exactly(
+          hash_including("args" => [extension.id])
+        )
+      end
+    end
+
+    it "answers accepted status" do
+      expect(response.status).to eq(202)
+    end
+
+    it "answers enqueued payload" do
+      expect(JSON(response.body.first, symbolize_names: true)).to eq(
+        data: {id: extension.id, enqueued: true}
+      )
+    end
+
+    context "with unknown extension" do
+      let :response do
+        action.call Rack::MockRequest.env_for("666", "router.params" => {extension_id: 666})
+      end
+
+      it "answers not found" do
+        expect(JSON(response.body.first, symbolize_names: true)).to include(status: 404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview

Adds `POST /api/extensions/:extension_id/build` — API parity with the UI's Build button — so automations can regenerate an extension's screens the moment source data changes instead of waiting for the extension's schedule. Answers `202` with `{"data": {"id": n, "enqueued": true}}`, or `404` problem details for unknown extensions.

## Details

- Mirrors the UI build action: enqueues `Jobs::Batches::Extension` for the extension.
- Specs cover the enqueue, the 202 payload, and the unknown-extension path; `doc/api.adoc` gains an Extensions section with request/response examples.
- Production use case: a webhook data pipeline (n8n) triggers a build after each data push — measured ~18s from data change to a freshly rendered screen, versus waiting up to a full schedule interval.