### PR TITLE
Add full.config.adoc + docker-compose-override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ public/*
 !public/404.html
 !public/500.html
 tmp
+configuration.adoc
+docker-compose.override.yml
+overide
+overide.yml

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,5 @@ public/*
 !public/404.html
 !public/500.html
 tmp
-configuration.adoc
+full.config.adoc
 docker-compose.override.yml
-overide
-overide.yml


### PR DESCRIPTION
## Overview

It can be useful to place a full.config.adoc in the root and to have Docker Compose override files when customising the configuration of a terminus server.
Both files should be ignored from git commits via the .gitignore.

## Details

1. full.config.adoc ignored from git commit
2. docker-compose-overide.yml ignored from git commit