### PR TITLE
Correct SVG attribute allowlist typos in config/sanitize.yml

### DIFF
--- a/config/sanitize.yml
+++ b/config/sanitize.yml
@@ -43,7 +43,7 @@ attributes:
     - height
   circle:
     - cx
-    - cv
+    - cy
     - r
     - stroke
     - stroke-dasharray
@@ -56,9 +56,9 @@ attributes:
     - transform
   ellipse:
     - cx
-    - cv
+    - cy
     - rx
-    - rv
+    - ry
     - stroke
     - stroke-dasharray
     - stroke-dashoffset
@@ -76,8 +76,8 @@ attributes:
   line:
     - x1
     - x2
-    - v1
-    - v2
+    - y1
+    - y2
     - stroke
     - stroke-dasharray
     - stroke-dashoffset


### PR DESCRIPTION
## Summary

Fix SVG sanitizer allowlist typos that caused Y-coordinate attributes to be stripped from user-supplied screen HTML:

- `circle`: `cv` should be `cy` (Y center coordinate)
- `ellipse`: `cv` should be `cy` (Y center), `rv` should be `ry` (Y radius)  
- `line`: `v1` should be `y1` (Y start), `v2` should be `y2` (Y end)

## Changes

- `config/sanitize.yml`:
  - `circle`: `cv` → `cy`
  - `ellipse`: `cv` → `cy`, `rv` → `ry`
  - `line`: `v1` → `y1`, `v2` → `y2`

Issue: 354